### PR TITLE
build(musl): add x86_64-unknown-linux-musl build target

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -65,6 +65,9 @@ jobs:
             target: aarch64-unknown-linux-gnu
             build: yarn build --target aarch64-unknown-linux-gnu --use-napi-cross
           - host: ubuntu-latest
+            target: x86_64-unknown-linux-musl
+            build: yarn build --target x86_64-unknown-linux-musl -x
+          - host: ubuntu-latest
             target: aarch64-unknown-linux-musl
             build: yarn build --target aarch64-unknown-linux-musl -x
           - host: windows-latest
@@ -176,6 +179,7 @@ jobs:
       matrix:
         target:
           - x86_64-unknown-linux-gnu
+          - x86_64-unknown-linux-musl
           - aarch64-unknown-linux-gnu
           - aarch64-unknown-linux-musl
         node:

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
       "x86_64-unknown-linux-gnu",
       "aarch64-unknown-linux-gnu",
       "aarch64-apple-darwin",
+      "x86_64-unknown-linux-musl",
       "aarch64-unknown-linux-musl",
       "aarch64-pc-windows-msvc"
     ]


### PR DESCRIPTION
## Summary

- `x86_64-unknown-linux-musl` was missing from the supported build targets despite `aarch64-unknown-linux-musl` being present, leaving musl-based x86_64 environments (e.g. Alpine Linux) without a native binary

## Changes

- Added `x86_64-unknown-linux-musl` to `package.json` napi targets
- Added build matrix entry in CI using Zig cross-compilation (`-x` flag), consistent with `aarch64-unknown-linux-musl`
- Added the target to the `test-linux-binding` matrix

Closes #1