### PR TITLE
ci: add dev branch to CI trigger

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -8,6 +8,7 @@ env:
   push:
     branches:
       - main
+      - dev
     tags-ignore:
       - '**'
     paths-ignore:


### PR DESCRIPTION
## Summary

CI was only triggered on pushes to `main`, so merges into `dev` ran no checks. This adds `dev` to the trigger so lint, build, and tests run on every push to `dev` as well.

The `publish` job remains unaffected — it is already gated with `if: github.event_name == 'push'`, and semantic-release is configured with `branches: ["main"]`, so it will correctly skip on `dev` pushes.

Closes #5