### PR TITLE
ci: optimize with rust-cache and separate PR workflow

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -3,7 +3,7 @@ env:
   DEBUG: napi:*
   APP_NAME: ehrmantraut
   MACOSX_DEPLOYMENT_TARGET: '10.13'
-  CARGO_INCREMENTAL: '1'
+  CARGO_INCREMENTAL: '0'
 'on':
   push:
     branches:
@@ -36,6 +36,8 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy, rustfmt
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
       - name: Install dependencies
         run: yarn install
       - name: Oxlint
@@ -88,16 +90,9 @@ jobs:
           toolchain: stable
           targets: ${{ matrix.settings.target }}
       - name: Cache cargo
-        uses: actions/cache@v5
+        uses: Swatinem/rust-cache@v2
         with:
-          path: |
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            ~/.napi-rs
-            .cargo-cache
-            target/
-          key: ${{ matrix.settings.target }}-cargo-${{ matrix.settings.host }}
+          key: ${{ matrix.settings.target }}
       - uses: mlugg/setup-zig@v2
         if: ${{ contains(matrix.settings.target, 'musl') }}
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Continuous Integration
 env:
   DEBUG: napi:*
   APP_NAME: ehrmantraut
@@ -17,7 +17,6 @@ env:
       - '**/*.gitignore'
       - .editorconfig
       - docs/**
-  pull_request: null
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -244,7 +243,6 @@ jobs:
       - lint
       - test-macOS-windows-binding
       - test-linux-binding
-    if: github.event_name == 'push'
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ${{ env.APP_NAME }}.*.node
-          key: build-${{ matrix.settings.target }}-${{ steps.rust-toolchain.outputs.cachekey }}-${{ hashFiles('src/**', 'Cargo.toml', 'Cargo.lock') }}
+          key: build-${{ matrix.settings.target }}-${{ steps.rust-toolchain.outputs.cachekey }}-${{ hashFiles('src/**', 'build.rs', 'Cargo.toml', 'Cargo.lock') }}
       - name: Cache cargo
         if: ${{ steps.build-cache.outputs.cache-hit != 'true' }}
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,32 +84,42 @@ jobs:
           node-version: 24
           cache: yarn
       - name: Install
+        id: rust-toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: stable
           targets: ${{ matrix.settings.target }}
+      - name: Cache build artifact
+        id: build-cache
+        uses: actions/cache@v5
+        with:
+          path: ${{ env.APP_NAME }}.*.node
+          key: build-${{ matrix.settings.target }}-${{ steps.rust-toolchain.outputs.cachekey }}-${{ hashFiles('src/**', 'Cargo.toml', 'Cargo.lock') }}
       - name: Cache cargo
+        if: ${{ steps.build-cache.outputs.cache-hit != 'true' }}
         uses: Swatinem/rust-cache@v2
         with:
           key: ${{ matrix.settings.target }}
       - uses: mlugg/setup-zig@v2
-        if: ${{ contains(matrix.settings.target, 'musl') }}
+        if: ${{ contains(matrix.settings.target, 'musl') && steps.build-cache.outputs.cache-hit != 'true' }}
         with:
           version: 0.14.1
       - name: Install cargo-zigbuild
         uses: taiki-e/install-action@v2
-        if: ${{ contains(matrix.settings.target, 'musl') }}
+        if: ${{ contains(matrix.settings.target, 'musl') && steps.build-cache.outputs.cache-hit != 'true' }}
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:
           tool: cargo-zigbuild
       - name: Setup toolchain
         run: ${{ matrix.settings.setup }}
-        if: ${{ matrix.settings.setup }}
+        if: ${{ matrix.settings.setup && steps.build-cache.outputs.cache-hit != 'true' }}
         shell: bash
       - name: Install dependencies
+        if: ${{ steps.build-cache.outputs.cache-hit != 'true' }}
         run: yarn install
       - name: Build
+        if: ${{ steps.build-cache.outputs.cache-hit != 'true' }}
         run: ${{ matrix.settings.build }}
         shell: bash
       - name: Upload artifact

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -81,7 +81,14 @@ jobs:
         with:
           tool: cargo-zigbuild
       - name: Install dependencies
+        if: ${{ !contains(matrix.settings.target, 'musl') }}
         run: yarn install
+      - name: Install dependencies (musl)
+        if: ${{ contains(matrix.settings.target, 'musl') }}
+        run: |
+          yarn config set --json supportedArchitectures.cpu '["current", "arm64", "x64", "arm"]'
+          yarn config set --json supportedArchitectures.libc '["current", "musl", "gnu"]'
+          yarn install
       - name: Build
         run: ${{ matrix.settings.build }}
         shell: bash

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -42,6 +42,9 @@ jobs:
           - host: ubuntu-latest
             target: x86_64-unknown-linux-gnu
             build: yarn build --target x86_64-unknown-linux-gnu --use-napi-cross
+          - host: ubuntu-latest
+            target: x86_64-unknown-linux-musl
+            build: yarn build --target x86_64-unknown-linux-musl -x
           - host: macos-latest
             target: aarch64-apple-darwin
             build: yarn build --target aarch64-apple-darwin
@@ -66,6 +69,17 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           key: ${{ matrix.settings.target }}
+      - uses: mlugg/setup-zig@v2
+        if: ${{ contains(matrix.settings.target, 'musl') }}
+        with:
+          version: 0.14.1
+      - name: Install cargo-zigbuild
+        uses: taiki-e/install-action@v2
+        if: ${{ contains(matrix.settings.target, 'musl') }}
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          tool: cargo-zigbuild
       - name: Install dependencies
         run: yarn install
       - name: Build
@@ -74,11 +88,19 @@ jobs:
       - name: Test bindings
         if: ${{ !contains(matrix.settings.target, 'linux') }}
         run: yarn test
-      - name: Test bindings (Linux)
-        if: ${{ contains(matrix.settings.target, 'linux') }}
+      - name: Test bindings (Linux gnu)
+        if: ${{ contains(matrix.settings.target, 'linux') && !contains(matrix.settings.target, 'musl') }}
         uses: tj-actions/docker-run@v2
         with:
           image: node:22-slim
+          name: test-bindings-${{ matrix.settings.target }}
+          options: '-v ${{ github.workspace }}:${{ github.workspace }} -w ${{ github.workspace }} --platform linux/amd64'
+          args: yarn test
+      - name: Test bindings (Linux musl)
+        if: ${{ contains(matrix.settings.target, 'musl') }}
+        uses: tj-actions/docker-run@v2
+        with:
+          image: node:22-alpine
           name: test-bindings-${{ matrix.settings.target }}
           options: '-v ${{ github.workspace }}:${{ github.workspace }} -w ${{ github.workspace }} --platform linux/amd64'
           args: yarn test

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -71,7 +71,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ${{ env.APP_NAME }}.*.node
-          key: build-${{ matrix.settings.target }}-${{ steps.rust-toolchain.outputs.cachekey }}-${{ hashFiles('src/**', 'Cargo.toml', 'Cargo.lock') }}
+          key: build-${{ matrix.settings.target }}-${{ steps.rust-toolchain.outputs.cachekey }}-${{ hashFiles('src/**', 'build.rs', 'Cargo.toml', 'Cargo.lock') }}
       - name: Cache cargo
         if: ${{ steps.build-cache.outputs.cache-hit != 'true' }}
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,172 @@
+name: Pull Request
+env:
+  DEBUG: napi:*
+  APP_NAME: ehrmantraut
+  MACOSX_DEPLOYMENT_TARGET: '10.13'
+  CARGO_INCREMENTAL: '0'
+'on':
+  pull_request: null
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Setup node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: yarn
+      - name: Install
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy, rustfmt
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
+      - name: Install dependencies
+        run: yarn install
+      - name: Oxlint
+        run: yarn lint
+      - name: Cargo fmt
+        run: cargo fmt -- --check
+      - name: Clippy
+        run: cargo clippy
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        settings:
+          - host: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            build: yarn build --target x86_64-unknown-linux-gnu --use-napi-cross
+          - host: macos-latest
+            target: aarch64-apple-darwin
+            build: yarn build --target aarch64-apple-darwin
+          - host: windows-latest
+            target: x86_64-pc-windows-msvc
+            build: yarn build --target x86_64-pc-windows-msvc
+    name: stable - ${{ matrix.settings.target }} - node@22
+    runs-on: ${{ matrix.settings.host }}
+    steps:
+      - uses: actions/checkout@v6
+      - name: Setup node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: yarn
+      - name: Install
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+          targets: ${{ matrix.settings.target }}
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
+        with:
+          key: ${{ matrix.settings.target }}
+      - name: Install dependencies
+        run: yarn install
+      - name: Build
+        run: ${{ matrix.settings.build }}
+        shell: bash
+      - name: Upload artifact
+        uses: actions/upload-artifact@v6
+        with:
+          name: bindings-${{ matrix.settings.target }}
+          path: |
+            ${{ env.APP_NAME }}.*.node
+            ${{ env.APP_NAME }}.*.wasm
+          if-no-files-found: error
+  test-macOS-windows-binding:
+    name: Test bindings on ${{ matrix.settings.target }} - node@22
+    needs:
+      - build
+    strategy:
+      fail-fast: false
+      matrix:
+        settings:
+          - host: windows-latest
+            target: x86_64-pc-windows-msvc
+            architecture: x64
+          - host: macos-latest
+            target: aarch64-apple-darwin
+            architecture: arm64
+    runs-on: ${{ matrix.settings.host }}
+    steps:
+      - uses: actions/checkout@v6
+      - name: Setup node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: yarn
+          architecture: ${{ matrix.settings.architecture }}
+      - name: Install dependencies
+        run: yarn install
+      - name: Download artifacts
+        uses: actions/download-artifact@v7
+        with:
+          name: bindings-${{ matrix.settings.target }}
+          path: .
+      - name: List packages
+        run: ls -R .
+        shell: bash
+      - name: Test bindings
+        run: yarn test
+  test-linux-binding:
+    name: Test ${{ matrix.target }} - node@22
+    needs:
+      - build
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - x86_64-unknown-linux-gnu
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Setup node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: yarn
+      - name: Output docker params
+        id: docker
+        run: |
+          node -e "
+            if ('${{ matrix.target }}'.startsWith('aarch64')) {
+              console.log('PLATFORM=linux/arm64')
+            } else if ('${{ matrix.target }}'.startsWith('armv7')) {
+              console.log('PLATFORM=linux/arm/v7')
+            } else {
+              console.log('PLATFORM=linux/amd64')
+            }
+          " >> $GITHUB_OUTPUT
+          node -e "
+            if ('${{ matrix.target }}'.endsWith('-musl')) {
+              console.log('IMAGE=node:22-alpine')
+            } else {
+              console.log('IMAGE=node:22-slim')
+            }
+          " >> $GITHUB_OUTPUT
+      - name: Install dependencies
+        run: |
+          yarn config set --json supportedArchitectures.cpu '["current", "arm64", "x64", "arm"]'
+          yarn config set --json supportedArchitectures.libc '["current", "musl", "gnu"]'
+          yarn install
+      - name: Download artifacts
+        uses: actions/download-artifact@v7
+        with:
+          name: bindings-${{ matrix.target }}
+          path: .
+      - name: List packages
+        run: ls -R .
+        shell: bash
+      - name: Test bindings
+        uses: tj-actions/docker-run@v2
+        with:
+          image: ${{ steps.docker.outputs.IMAGE }}
+          name: test-bindings-${{ matrix.target }}
+          options: '-v ${{ github.workspace }}:${{ github.workspace }} -w ${{ github.workspace }} --platform ${{ steps.docker.outputs.PLATFORM }}'
+          args: yarn test

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -34,7 +34,7 @@ jobs:
         run: cargo fmt -- --check
       - name: Clippy
         run: cargo clippy
-  build:
+  build-and-test:
     strategy:
       fail-fast: false
       matrix:
@@ -48,14 +48,14 @@ jobs:
           - host: windows-latest
             target: x86_64-pc-windows-msvc
             build: yarn build --target x86_64-pc-windows-msvc
-    name: stable - ${{ matrix.settings.target }} - node@22
+    name: Build & Test - ${{ matrix.settings.target }}
     runs-on: ${{ matrix.settings.host }}
     steps:
       - uses: actions/checkout@v6
       - name: Setup node
         uses: actions/setup-node@v6
         with:
-          node-version: 24
+          node-version: 22
           cache: yarn
       - name: Install
         uses: dtolnay/rust-toolchain@stable
@@ -71,102 +71,14 @@ jobs:
       - name: Build
         run: ${{ matrix.settings.build }}
         shell: bash
-      - name: Upload artifact
-        uses: actions/upload-artifact@v6
-        with:
-          name: bindings-${{ matrix.settings.target }}
-          path: |
-            ${{ env.APP_NAME }}.*.node
-            ${{ env.APP_NAME }}.*.wasm
-          if-no-files-found: error
-  test-macOS-windows-binding:
-    name: Test bindings on ${{ matrix.settings.target }} - node@22
-    needs:
-      - build
-    strategy:
-      fail-fast: false
-      matrix:
-        settings:
-          - host: windows-latest
-            target: x86_64-pc-windows-msvc
-            architecture: x64
-          - host: macos-latest
-            target: aarch64-apple-darwin
-            architecture: arm64
-    runs-on: ${{ matrix.settings.host }}
-    steps:
-      - uses: actions/checkout@v6
-      - name: Setup node
-        uses: actions/setup-node@v6
-        with:
-          node-version: 22
-          cache: yarn
-          architecture: ${{ matrix.settings.architecture }}
-      - name: Install dependencies
-        run: yarn install
-      - name: Download artifacts
-        uses: actions/download-artifact@v7
-        with:
-          name: bindings-${{ matrix.settings.target }}
-          path: .
-      - name: List packages
-        run: ls -R .
-        shell: bash
       - name: Test bindings
+        if: ${{ !contains(matrix.settings.target, 'linux') }}
         run: yarn test
-  test-linux-binding:
-    name: Test ${{ matrix.target }} - node@22
-    needs:
-      - build
-    strategy:
-      fail-fast: false
-      matrix:
-        target:
-          - x86_64-unknown-linux-gnu
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - name: Setup node
-        uses: actions/setup-node@v6
-        with:
-          node-version: 22
-          cache: yarn
-      - name: Output docker params
-        id: docker
-        run: |
-          node -e "
-            if ('${{ matrix.target }}'.startsWith('aarch64')) {
-              console.log('PLATFORM=linux/arm64')
-            } else if ('${{ matrix.target }}'.startsWith('armv7')) {
-              console.log('PLATFORM=linux/arm/v7')
-            } else {
-              console.log('PLATFORM=linux/amd64')
-            }
-          " >> $GITHUB_OUTPUT
-          node -e "
-            if ('${{ matrix.target }}'.endsWith('-musl')) {
-              console.log('IMAGE=node:22-alpine')
-            } else {
-              console.log('IMAGE=node:22-slim')
-            }
-          " >> $GITHUB_OUTPUT
-      - name: Install dependencies
-        run: |
-          yarn config set --json supportedArchitectures.cpu '["current", "arm64", "x64", "arm"]'
-          yarn config set --json supportedArchitectures.libc '["current", "musl", "gnu"]'
-          yarn install
-      - name: Download artifacts
-        uses: actions/download-artifact@v7
-        with:
-          name: bindings-${{ matrix.target }}
-          path: .
-      - name: List packages
-        run: ls -R .
-        shell: bash
-      - name: Test bindings
+      - name: Test bindings (Linux)
+        if: ${{ contains(matrix.settings.target, 'linux') }}
         uses: tj-actions/docker-run@v2
         with:
-          image: ${{ steps.docker.outputs.IMAGE }}
-          name: test-bindings-${{ matrix.target }}
-          options: '-v ${{ github.workspace }}:${{ github.workspace }} -w ${{ github.workspace }} --platform ${{ steps.docker.outputs.PLATFORM }}'
+          image: node:22-slim
+          name: test-bindings-${{ matrix.settings.target }}
+          options: '-v ${{ github.workspace }}:${{ github.workspace }} -w ${{ github.workspace }} --platform linux/amd64'
           args: yarn test

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -61,21 +61,29 @@ jobs:
           node-version: 22
           cache: yarn
       - name: Install
+        id: rust-toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: stable
           targets: ${{ matrix.settings.target }}
+      - name: Cache build artifact
+        id: build-cache
+        uses: actions/cache@v5
+        with:
+          path: ${{ env.APP_NAME }}.*.node
+          key: build-${{ matrix.settings.target }}-${{ steps.rust-toolchain.outputs.cachekey }}-${{ hashFiles('src/**', 'Cargo.toml', 'Cargo.lock') }}
       - name: Cache cargo
+        if: ${{ steps.build-cache.outputs.cache-hit != 'true' }}
         uses: Swatinem/rust-cache@v2
         with:
           key: ${{ matrix.settings.target }}
       - uses: mlugg/setup-zig@v2
-        if: ${{ contains(matrix.settings.target, 'musl') }}
+        if: ${{ contains(matrix.settings.target, 'musl') && steps.build-cache.outputs.cache-hit != 'true' }}
         with:
           version: 0.14.1
       - name: Install cargo-zigbuild
         uses: taiki-e/install-action@v2
-        if: ${{ contains(matrix.settings.target, 'musl') }}
+        if: ${{ contains(matrix.settings.target, 'musl') && steps.build-cache.outputs.cache-hit != 'true' }}
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:
@@ -90,6 +98,7 @@ jobs:
           yarn config set --json supportedArchitectures.libc '["current", "musl", "gnu"]'
           yarn install
       - name: Build
+        if: ${{ steps.build-cache.outputs.cache-hit != 'true' }}
         run: ${{ matrix.settings.build }}
         shell: bash
       - name: Test bindings


### PR DESCRIPTION
## Summary

Optimize CI by fixing Rust caching, splitting into separate push/PR workflows, and adding build artifact caching for faster feedback.

## Changes

### Rust caching
- Replace ineffective `actions/cache@v5` with `Swatinem/rust-cache@v2` in both workflows
- Add Rust cache to lint job (previously had none)
- Set `CARGO_INCREMENTAL=0` as recommended for CI

### Workflow split
- **`ci.yml`** (push to dev/main): Full pipeline — lint + 8-target build + 16 tests + publish
- **`pr.yml`** (pull requests): Fast feedback — lint + 4-target build + 4 tests (node@22 only)
- Rename workflow display names to "Continuous Integration" and "Pull Request"

### PR workflow build targets
- `x86_64-unknown-linux-gnu` — primary Linux target
- `x86_64-unknown-linux-musl` — validates musl/zigbuild toolchain (different build chain from glibc)
- `aarch64-apple-darwin` — macOS ARM
- `x86_64-pc-windows-msvc` — Windows

### Build artifact caching
- Cache the built `.node` artifact keyed by `{target}-{rustc version}-{source hash}`
- On cache hit, skip entire cargo build and build-only dependencies (rust-cache, zig, cargo-zigbuild)
- Eliminates unnecessary recompilation caused by `actions/checkout` resetting file mtimes

### Expected impact
- **PR (cache miss)**: ~2-3 min
- **PR (cache hit)**: ~30s (build skipped entirely)
- **Push to dev/main**: unchanged

Closes #7