### PR TITLE
ci: fix workspace build for napi-rs multi-crate structure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,28 +52,28 @@ jobs:
         settings:
           - host: macos-latest
             target: x86_64-apple-darwin
-            build: yarn build --target x86_64-apple-darwin
+            build: napi build -p ehrmantraut --platform --release --target x86_64-apple-darwin
           - host: windows-latest
-            build: yarn build --target x86_64-pc-windows-msvc
             target: x86_64-pc-windows-msvc
+            build: napi build -p ehrmantraut --platform --release --target x86_64-pc-windows-msvc
           - host: ubuntu-latest
             target: x86_64-unknown-linux-gnu
-            build: yarn build --target x86_64-unknown-linux-gnu --use-napi-cross
+            build: napi build -p ehrmantraut --platform --release --target x86_64-unknown-linux-gnu --use-napi-cross
           - host: macos-latest
             target: aarch64-apple-darwin
-            build: yarn build --target aarch64-apple-darwin
+            build: napi build -p ehrmantraut --platform --release --target aarch64-apple-darwin
           - host: ubuntu-latest
             target: aarch64-unknown-linux-gnu
-            build: yarn build --target aarch64-unknown-linux-gnu --use-napi-cross
+            build: napi build -p ehrmantraut --platform --release --target aarch64-unknown-linux-gnu --use-napi-cross
           - host: ubuntu-latest
             target: x86_64-unknown-linux-musl
-            build: yarn build --target x86_64-unknown-linux-musl -x
+            build: napi build -p ehrmantraut --platform --release --target x86_64-unknown-linux-musl -x
           - host: ubuntu-latest
             target: aarch64-unknown-linux-musl
-            build: yarn build --target aarch64-unknown-linux-musl -x
+            build: napi build -p ehrmantraut --platform --release --target aarch64-unknown-linux-musl -x
           - host: windows-latest
             target: aarch64-pc-windows-msvc
-            build: yarn build --target aarch64-pc-windows-msvc
+            build: napi build -p ehrmantraut --platform --release --target aarch64-pc-windows-msvc
     name: stable - ${{ matrix.settings.target }} - node@22
     runs-on: ${{ matrix.settings.host }}
     steps:
@@ -123,6 +123,9 @@ jobs:
       - name: Build
         if: ${{ steps.build-cache.outputs.cache-hit != 'true' }}
         run: ${{ matrix.settings.build }}
+        shell: bash
+      - name: Copy native binding to root
+        run: cp crates/napi/${{ env.APP_NAME }}.*.node . 2>/dev/null || true
         shell: bash
       - name: Upload artifact
         uses: actions/upload-artifact@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,8 +93,10 @@ jobs:
         id: build-cache
         uses: actions/cache@v5
         with:
-          path: ${{ env.APP_NAME }}.*.node
-          key: build-${{ matrix.settings.target }}-${{ steps.rust-toolchain.outputs.cachekey }}-${{ hashFiles('src/**', 'build.rs', 'Cargo.toml', 'Cargo.lock') }}
+          path: |
+            ${{ env.APP_NAME }}.*.node
+            crates/napi/${{ env.APP_NAME }}.*.node
+          key: build-${{ matrix.settings.target }}-${{ steps.rust-toolchain.outputs.cachekey }}-${{ hashFiles('crates/**', 'Cargo.toml', 'Cargo.lock') }}
       - name: Cache cargo
         if: ${{ steps.build-cache.outputs.cache-hit != 'true' }}
         uses: Swatinem/rust-cache@v2
@@ -128,7 +130,7 @@ jobs:
           name: bindings-${{ matrix.settings.target }}
           path: |
             ${{ env.APP_NAME }}.*.node
-            ${{ env.APP_NAME }}.*.wasm
+            crates/napi/${{ env.APP_NAME }}.*.node
           if-no-files-found: error
   test-macOS-windows-binding:
     name: Test bindings on ${{ matrix.settings.target }} - node@${{ matrix.node }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,7 +125,14 @@ jobs:
         run: ${{ matrix.settings.build }}
         shell: bash
       - name: Copy native binding to root
-        run: cp crates/napi/${{ env.APP_NAME }}.*.node . 2>/dev/null || true
+        run: |
+          if compgen -G "crates/napi/${{ env.APP_NAME }}.*.node" > /dev/null; then
+            cp crates/napi/${{ env.APP_NAME }}.*.node .
+          fi
+          if ! compgen -G "${{ env.APP_NAME }}.*.node" > /dev/null; then
+            echo "Error: native binding '${{ env.APP_NAME }}.*.node' not found"
+            exit 1
+          fi
         shell: bash
       - name: Upload artifact
         uses: actions/upload-artifact@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,28 +52,28 @@ jobs:
         settings:
           - host: macos-latest
             target: x86_64-apple-darwin
-            build: napi build -p ehrmantraut --platform --release --target x86_64-apple-darwin
+            build: npx napi build -p ehrmantraut --platform --release --target x86_64-apple-darwin
           - host: windows-latest
             target: x86_64-pc-windows-msvc
-            build: napi build -p ehrmantraut --platform --release --target x86_64-pc-windows-msvc
+            build: npx napi build -p ehrmantraut --platform --release --target x86_64-pc-windows-msvc
           - host: ubuntu-latest
             target: x86_64-unknown-linux-gnu
-            build: napi build -p ehrmantraut --platform --release --target x86_64-unknown-linux-gnu --use-napi-cross
+            build: npx napi build -p ehrmantraut --platform --release --target x86_64-unknown-linux-gnu --use-napi-cross
           - host: macos-latest
             target: aarch64-apple-darwin
-            build: napi build -p ehrmantraut --platform --release --target aarch64-apple-darwin
+            build: npx napi build -p ehrmantraut --platform --release --target aarch64-apple-darwin
           - host: ubuntu-latest
             target: aarch64-unknown-linux-gnu
-            build: napi build -p ehrmantraut --platform --release --target aarch64-unknown-linux-gnu --use-napi-cross
+            build: npx napi build -p ehrmantraut --platform --release --target aarch64-unknown-linux-gnu --use-napi-cross
           - host: ubuntu-latest
             target: x86_64-unknown-linux-musl
-            build: napi build -p ehrmantraut --platform --release --target x86_64-unknown-linux-musl -x
+            build: npx napi build -p ehrmantraut --platform --release --target x86_64-unknown-linux-musl -x
           - host: ubuntu-latest
             target: aarch64-unknown-linux-musl
-            build: napi build -p ehrmantraut --platform --release --target aarch64-unknown-linux-musl -x
+            build: npx napi build -p ehrmantraut --platform --release --target aarch64-unknown-linux-musl -x
           - host: windows-latest
             target: aarch64-pc-windows-msvc
-            build: napi build -p ehrmantraut --platform --release --target aarch64-pc-windows-msvc
+            build: npx napi build -p ehrmantraut --platform --release --target aarch64-pc-windows-msvc
     name: stable - ${{ matrix.settings.target }} - node@22
     runs-on: ${{ matrix.settings.host }}
     steps:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -41,16 +41,16 @@ jobs:
         settings:
           - host: ubuntu-latest
             target: x86_64-unknown-linux-gnu
-            build: yarn build --target x86_64-unknown-linux-gnu --use-napi-cross
+            build: napi build -p ehrmantraut --platform --release --target x86_64-unknown-linux-gnu --use-napi-cross
           - host: ubuntu-latest
             target: x86_64-unknown-linux-musl
-            build: yarn build --target x86_64-unknown-linux-musl -x
+            build: napi build -p ehrmantraut --platform --release --target x86_64-unknown-linux-musl -x
           - host: macos-latest
             target: aarch64-apple-darwin
-            build: yarn build --target aarch64-apple-darwin
+            build: napi build -p ehrmantraut --platform --release --target aarch64-apple-darwin
           - host: windows-latest
             target: x86_64-pc-windows-msvc
-            build: yarn build --target x86_64-pc-windows-msvc
+            build: napi build -p ehrmantraut --platform --release --target x86_64-pc-windows-msvc
     name: Build & Test - ${{ matrix.settings.target }}
     runs-on: ${{ matrix.settings.host }}
     steps:
@@ -102,6 +102,9 @@ jobs:
       - name: Build
         if: ${{ steps.build-cache.outputs.cache-hit != 'true' }}
         run: ${{ matrix.settings.build }}
+        shell: bash
+      - name: Copy native binding to root
+        run: cp crates/napi/${{ env.APP_NAME }}.*.node . 2>/dev/null || true
         shell: bash
       - name: Test bindings
         if: ${{ !contains(matrix.settings.target, 'linux') }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -104,7 +104,14 @@ jobs:
         run: ${{ matrix.settings.build }}
         shell: bash
       - name: Copy native binding to root
-        run: cp crates/napi/${{ env.APP_NAME }}.*.node . 2>/dev/null || true
+        run: |
+          if compgen -G "crates/napi/${{ env.APP_NAME }}.*.node" > /dev/null; then
+            cp crates/napi/${{ env.APP_NAME }}.*.node .
+          fi
+          if ! compgen -G "${{ env.APP_NAME }}.*.node" > /dev/null; then
+            echo "Error: native binding '${{ env.APP_NAME }}.*.node' not found"
+            exit 1
+          fi
         shell: bash
       - name: Test bindings
         if: ${{ !contains(matrix.settings.target, 'linux') }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -70,8 +70,10 @@ jobs:
         id: build-cache
         uses: actions/cache@v5
         with:
-          path: ${{ env.APP_NAME }}.*.node
-          key: build-${{ matrix.settings.target }}-${{ steps.rust-toolchain.outputs.cachekey }}-${{ hashFiles('src/**', 'build.rs', 'Cargo.toml', 'Cargo.lock') }}
+          path: |
+            ${{ env.APP_NAME }}.*.node
+            crates/napi/${{ env.APP_NAME }}.*.node
+          key: build-${{ matrix.settings.target }}-${{ steps.rust-toolchain.outputs.cachekey }}-${{ hashFiles('crates/**', 'Cargo.toml', 'Cargo.lock') }}
       - name: Cache cargo
         if: ${{ steps.build-cache.outputs.cache-hit != 'true' }}
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -41,16 +41,16 @@ jobs:
         settings:
           - host: ubuntu-latest
             target: x86_64-unknown-linux-gnu
-            build: napi build -p ehrmantraut --platform --release --target x86_64-unknown-linux-gnu --use-napi-cross
+            build: npx napi build -p ehrmantraut --platform --release --target x86_64-unknown-linux-gnu --use-napi-cross
           - host: ubuntu-latest
             target: x86_64-unknown-linux-musl
-            build: napi build -p ehrmantraut --platform --release --target x86_64-unknown-linux-musl -x
+            build: npx napi build -p ehrmantraut --platform --release --target x86_64-unknown-linux-musl -x
           - host: macos-latest
             target: aarch64-apple-darwin
-            build: napi build -p ehrmantraut --platform --release --target aarch64-apple-darwin
+            build: npx napi build -p ehrmantraut --platform --release --target aarch64-apple-darwin
           - host: windows-latest
             target: x86_64-pc-windows-msvc
-            build: napi build -p ehrmantraut --platform --release --target x86_64-pc-windows-msvc
+            build: npx napi build -p ehrmantraut --platform --release --target x86_64-pc-windows-msvc
     name: Build & Test - ${{ matrix.settings.target }}
     runs-on: ${{ matrix.settings.host }}
     steps:


### PR DESCRIPTION
## Summary

Fixes CI build and test failures caused by the workspace restructure (single crate → multi-crate). The napi-rs build outputs `.node` files to `crates/napi/` instead of root, and the `napi` CLI isn't directly available in PATH without yarn/npx.

## Changes

- Update build artifact cache keys from `src/**` to `crates/**`
- Add cache paths for both root and `crates/napi/` `.node` files
- Use `npx napi build` instead of `napi build` directly in CI matrix
- Add post-build step to copy `.node` files from `crates/napi/` to root

## Test plan

- [ ] All 4 CI targets pass (gnu, musl, macOS, Windows)
- [ ] Build cache hit/miss both work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)