### PR TITLE
ci: run aarch64-linux-gnu test natively on arm64 runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -248,7 +248,11 @@ jobs:
           platforms: all
       - run: docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
         if: ${{ contains(matrix.target, 'armv7') }}
-      - name: Test bindings
+      - name: Test bindings (native)
+        if: ${{ matrix.target == 'aarch64-unknown-linux-gnu' }}
+        run: yarn test
+      - name: Test bindings (docker)
+        if: ${{ matrix.target != 'aarch64-unknown-linux-gnu' }}
         uses: tj-actions/docker-run@v2
         with:
           image: ${{ steps.docker.outputs.IMAGE }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -241,6 +241,10 @@ jobs:
       - name: List packages
         run: ls -R .
         shell: bash
+      - name: Check binary dependencies
+        if: ${{ matrix.target == 'aarch64-unknown-linux-gnu' }}
+        run: ldd ehrmantraut.linux-arm64-gnu.node || true
+        shell: bash
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
         if: ${{ contains(matrix.target, 'armv7') }}


### PR DESCRIPTION
## Summary

- tree-sitter's `__atomic_*` GCC built-ins may produce a binary that dynamically links `libatomic.so.1` when cross-compiled for aarch64
- `node:20-slim` (Debian Bookworm slim) does not include `libatomic1`, causing `require('./ehrmantraut.linux-arm64-gnu.node')` to fail at runtime
- The `ubuntu-24.04-arm` runner is already a native arm64/glibc environment, so Docker is unnecessary for this target

## Changes

- Split the `Test bindings` step into two conditional steps:
  - `Test bindings (native)`: runs `yarn test` directly on the `ubuntu-24.04-arm` host for `aarch64-unknown-linux-gnu`
  - `Test bindings (docker)`: keeps the existing Docker-based approach for all other Linux targets (x86_64-gnu, x86_64-musl, aarch64-musl)

Closes #14