### PR TITLE
build(release): publish prerelease versions from dev branch

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,5 +1,5 @@
 {
-  "branches": ["main"],
+  "branches": ["main", { "name": "dev", "prerelease": true }],
   "plugins": [
     "@semantic-release/commit-analyzer",
     "@semantic-release/release-notes-generator",


### PR DESCRIPTION
## Summary

- Add `dev` as a prerelease channel in `.releaserc.json`
- Versions on `dev` will follow the pattern `X.Y.Z-dev.N` and be published under the `dev` npm dist-tag
- `main` branch continues to publish stable releases as before

## Changes

`.releaserc.json` — `branches` extended from `["main"]` to `["main", { "name": "dev", "prerelease": true }]`

Closes #18