### PR TITLE
feat(lowering): add unary, update, conditional, array, and object expression lowering

### DIFF
--- a/__test__/lower.spec.ts
+++ b/__test__/lower.spec.ts
@@ -246,3 +246,198 @@ test('lower JS class declaration with extends', (t) => {
   t.is(node.name, 'Bar')
   t.truthy(node.superClass)
 })
+
+// ── unary expressions ──────────────────────────────────────────────
+
+test('lower JS unary not expression', (t) => {
+  const node = lower('!x;', 'javascript').body[0]
+  if (node.type !== 'expressionStatement') return t.fail()
+  if (node.expression.type !== 'unaryExpr') return t.fail()
+  t.is(node.expression.operator, '!')
+  t.is(node.expression.prefix, true)
+  if (node.expression.operand.type !== 'identifier') return t.fail()
+  t.is(node.expression.operand.name, 'x')
+})
+
+test('lower JS typeof expression', (t) => {
+  const node = lower('typeof x;', 'javascript').body[0]
+  if (node.type !== 'expressionStatement') return t.fail()
+  if (node.expression.type !== 'unaryExpr') return t.fail()
+  t.is(node.expression.operator, 'typeof')
+  t.is(node.expression.prefix, true)
+})
+
+test('lower JS void expression', (t) => {
+  const node = lower('void 0;', 'javascript').body[0]
+  if (node.type !== 'expressionStatement') return t.fail()
+  if (node.expression.type !== 'unaryExpr') return t.fail()
+  t.is(node.expression.operator, 'void')
+})
+
+test('lower JS delete expression', (t) => {
+  const node = lower('delete obj.key;', 'javascript').body[0]
+  if (node.type !== 'expressionStatement') return t.fail()
+  if (node.expression.type !== 'unaryExpr') return t.fail()
+  t.is(node.expression.operator, 'delete')
+})
+
+test('lower JS unary minus expression', (t) => {
+  const node = lower('-x;', 'javascript').body[0]
+  if (node.type !== 'expressionStatement') return t.fail()
+  if (node.expression.type !== 'unaryExpr') return t.fail()
+  t.is(node.expression.operator, '-')
+})
+
+// ── update expressions ─────────────────────────────────────────────
+
+test('lower JS prefix increment', (t) => {
+  const node = lower('++x;', 'javascript').body[0]
+  if (node.type !== 'expressionStatement') return t.fail()
+  if (node.expression.type !== 'updateExpr') return t.fail()
+  t.is(node.expression.operator, '++')
+  t.is(node.expression.prefix, true)
+})
+
+test('lower JS postfix increment', (t) => {
+  const node = lower('x++;', 'javascript').body[0]
+  if (node.type !== 'expressionStatement') return t.fail()
+  if (node.expression.type !== 'updateExpr') return t.fail()
+  t.is(node.expression.operator, '++')
+  t.is(node.expression.prefix, false)
+})
+
+test('lower JS prefix decrement', (t) => {
+  const node = lower('--x;', 'javascript').body[0]
+  if (node.type !== 'expressionStatement') return t.fail()
+  if (node.expression.type !== 'updateExpr') return t.fail()
+  t.is(node.expression.operator, '--')
+  t.is(node.expression.prefix, true)
+})
+
+test('lower JS postfix decrement', (t) => {
+  const node = lower('x--;', 'javascript').body[0]
+  if (node.type !== 'expressionStatement') return t.fail()
+  if (node.expression.type !== 'updateExpr') return t.fail()
+  t.is(node.expression.operator, '--')
+  t.is(node.expression.prefix, false)
+})
+
+// ── conditional (ternary) expression ───────────────────────────────
+
+test('lower JS ternary expression', (t) => {
+  const node = lower('a ? b : c;', 'javascript').body[0]
+  if (node.type !== 'expressionStatement') return t.fail()
+  if (node.expression.type !== 'conditionalExpr') return t.fail()
+  if (node.expression.condition.type !== 'identifier') return t.fail()
+  t.is(node.expression.condition.name, 'a')
+  if (node.expression.consequent.type !== 'identifier') return t.fail()
+  t.is(node.expression.consequent.name, 'b')
+  if (node.expression.alternate.type !== 'identifier') return t.fail()
+  t.is(node.expression.alternate.name, 'c')
+})
+
+test('lower JS nested ternary expression', (t) => {
+  const node = lower('a ? b : c ? d : e;', 'javascript').body[0]
+  if (node.type !== 'expressionStatement') return t.fail()
+  if (node.expression.type !== 'conditionalExpr') return t.fail()
+  t.is(node.expression.alternate.type, 'conditionalExpr')
+})
+
+// ── array expression ───────────────────────────────────────────────
+
+test('lower JS basic array expression', (t) => {
+  const node = lower('[1, 2, 3];', 'javascript').body[0]
+  if (node.type !== 'expressionStatement') return t.fail()
+  if (node.expression.type !== 'arrayExpr') return t.fail()
+  t.is(node.expression.elements.length, 3)
+  for (const elem of node.expression.elements) {
+    if (!elem) return t.fail()
+    t.is(elem.type, 'literal')
+  }
+})
+
+test('lower JS sparse array (holes)', (t) => {
+  const node = lower('[1, , 3];', 'javascript').body[0]
+  if (node.type !== 'expressionStatement') return t.fail()
+  if (node.expression.type !== 'arrayExpr') return t.fail()
+  t.is(node.expression.elements.length, 3)
+  t.truthy(node.expression.elements[0])
+  t.is(node.expression.elements[1], null)
+  t.truthy(node.expression.elements[2])
+})
+
+test('lower JS empty array', (t) => {
+  const node = lower('[];', 'javascript').body[0]
+  if (node.type !== 'expressionStatement') return t.fail()
+  if (node.expression.type !== 'arrayExpr') return t.fail()
+  t.is(node.expression.elements.length, 0)
+})
+
+test('lower JS array with nested expressions', (t) => {
+  const node = lower('[a + b, fn()];', 'javascript').body[0]
+  if (node.type !== 'expressionStatement') return t.fail()
+  if (node.expression.type !== 'arrayExpr') return t.fail()
+  t.is(node.expression.elements.length, 2)
+  const first = node.expression.elements[0]
+  const second = node.expression.elements[1]
+  if (!first || !second) return t.fail()
+  t.is(first.type, 'binaryExpr')
+  t.is(second.type, 'call')
+})
+
+// ── object expression ──────────────────────────────────────────────
+
+test('lower JS basic object expression', (t) => {
+  const node = lower('({a: 1, b: 2});', 'javascript').body[0]
+  if (node.type !== 'expressionStatement') return t.fail()
+  if (node.expression.type !== 'objectExpr') return t.fail()
+  t.is(node.expression.properties.length, 2)
+  t.is(node.expression.properties[0].kind, 'keyValue')
+  t.is(node.expression.properties[1].kind, 'keyValue')
+})
+
+test('lower JS object shorthand property', (t) => {
+  const node = lower('({x, y});', 'javascript').body[0]
+  if (node.type !== 'expressionStatement') return t.fail()
+  if (node.expression.type !== 'objectExpr') return t.fail()
+  t.is(node.expression.properties.length, 2)
+  t.is(node.expression.properties[0].kind, 'shorthand')
+  if (node.expression.properties[0].kind !== 'shorthand') return t.fail()
+  t.is(node.expression.properties[0].name, 'x')
+})
+
+test('lower JS object computed property', (t) => {
+  const node = lower('({["a"]: 1});', 'javascript').body[0]
+  if (node.type !== 'expressionStatement') return t.fail()
+  if (node.expression.type !== 'objectExpr') return t.fail()
+  if (node.expression.properties[0].kind !== 'keyValue') return t.fail()
+  t.is(node.expression.properties[0].computed, true)
+})
+
+test('lower JS object method shorthand', (t) => {
+  const node = lower('({foo() { return 1 }});', 'javascript').body[0]
+  if (node.type !== 'expressionStatement') return t.fail()
+  if (node.expression.type !== 'objectExpr') return t.fail()
+  t.is(node.expression.properties[0].kind, 'method')
+  if (node.expression.properties[0].kind !== 'method') return t.fail()
+  if (node.expression.properties[0].key.type !== 'identifier') return t.fail()
+  t.is(node.expression.properties[0].key.name, 'foo')
+})
+
+test('lower JS object getter and setter', (t) => {
+  const node = lower('({get x() { return 1 }, set x(v) { }});', 'javascript').body[0]
+  if (node.type !== 'expressionStatement') return t.fail()
+  if (node.expression.type !== 'objectExpr') return t.fail()
+  t.is(node.expression.properties.length, 2)
+  if (node.expression.properties[0].kind !== 'accessor') return t.fail()
+  t.is(node.expression.properties[0].accessorKind, 'get')
+  if (node.expression.properties[1].kind !== 'accessor') return t.fail()
+  t.is(node.expression.properties[1].accessorKind, 'set')
+})
+
+test('lower JS empty object', (t) => {
+  const node = lower('({});', 'javascript').body[0]
+  if (node.type !== 'expressionStatement') return t.fail()
+  if (node.expression.type !== 'objectExpr') return t.fail()
+  t.is(node.expression.properties.length, 0)
+})

--- a/crates/core/src/ir.rs
+++ b/crates/core/src/ir.rs
@@ -56,6 +56,11 @@ pub enum IrExpr {
   BinaryExpr(BinaryExpr),
   Identifier(Identifier),
   Literal(Literal),
+  UnaryExpr(UnaryExpr),
+  UpdateExpr(UpdateExpr),
+  ConditionalExpr(ConditionalExpr),
+  ArrayExpr(ArrayExpr),
+  ObjectExpr(ObjectExpr),
   // Catch-all for expressions we don't lower in detail
   Opaque(OpaqueExpr),
 }
@@ -333,6 +338,125 @@ pub enum DeclKind {
   Function,
   Class,
   Import,
+}
+
+// ── Unary / Update / Conditional ─────────────────────────────────────
+
+#[derive(Debug, Clone, Serialize, TS)]
+#[ts(export, export_to = "../../bindings/")]
+#[serde(rename_all = "camelCase")]
+pub struct UnaryExpr {
+  pub span: Span,
+  pub operator: String,
+  pub operand: Box<IrExpr>,
+  pub prefix: bool,
+}
+
+#[derive(Debug, Clone, Serialize, TS)]
+#[ts(export, export_to = "../../bindings/")]
+#[serde(rename_all = "camelCase")]
+pub struct UpdateExpr {
+  pub span: Span,
+  pub operator: String,
+  pub operand: Box<IrExpr>,
+  pub prefix: bool,
+}
+
+#[derive(Debug, Clone, Serialize, TS)]
+#[ts(export, export_to = "../../bindings/")]
+#[serde(rename_all = "camelCase")]
+pub struct ConditionalExpr {
+  pub span: Span,
+  pub condition: Box<IrExpr>,
+  pub consequent: Box<IrExpr>,
+  pub alternate: Box<IrExpr>,
+}
+
+// ── Array / Object literals ─────────────────────────────────────────
+
+#[derive(Debug, Clone, Serialize, TS)]
+#[ts(export, export_to = "../../bindings/")]
+#[serde(rename_all = "camelCase")]
+pub struct ArrayExpr {
+  pub span: Span,
+  pub elements: Vec<Option<IrExpr>>,
+}
+
+#[derive(Debug, Clone, Serialize, TS)]
+#[ts(export, export_to = "../../bindings/")]
+#[serde(rename_all = "camelCase")]
+pub struct ObjectExpr {
+  pub span: Span,
+  pub properties: Vec<ObjectProperty>,
+}
+
+#[derive(Debug, Clone, Serialize, TS)]
+#[ts(export, export_to = "../../bindings/")]
+#[serde(tag = "kind", rename_all = "camelCase")]
+pub enum ObjectProperty {
+  KeyValue(KeyValueProperty),
+  Shorthand(ShorthandProperty),
+  Method(MethodProperty),
+  Accessor(AccessorProperty),
+  Spread(SpreadProperty),
+}
+
+#[derive(Debug, Clone, Serialize, TS)]
+#[ts(export, export_to = "../../bindings/")]
+#[serde(rename_all = "camelCase")]
+pub struct KeyValueProperty {
+  pub span: Span,
+  pub key: IrExpr,
+  pub value: IrExpr,
+  pub computed: bool,
+}
+
+#[derive(Debug, Clone, Serialize, TS)]
+#[ts(export, export_to = "../../bindings/")]
+#[serde(rename_all = "camelCase")]
+pub struct ShorthandProperty {
+  pub span: Span,
+  pub name: String,
+}
+
+#[derive(Debug, Clone, Serialize, TS)]
+#[ts(export, export_to = "../../bindings/")]
+#[serde(rename_all = "camelCase")]
+pub struct MethodProperty {
+  pub span: Span,
+  pub key: IrExpr,
+  pub params: Vec<Param>,
+  pub body: Block,
+  pub computed: bool,
+  pub is_async: bool,
+  pub is_generator: bool,
+}
+
+#[derive(Debug, Clone, Serialize, TS)]
+#[ts(export, export_to = "../../bindings/")]
+#[serde(rename_all = "camelCase")]
+pub struct AccessorProperty {
+  pub span: Span,
+  pub key: IrExpr,
+  pub accessor_kind: AccessorKind,
+  pub params: Vec<Param>,
+  pub body: Block,
+}
+
+#[derive(Debug, Clone, Serialize, TS)]
+#[ts(export, export_to = "../../bindings/")]
+#[serde(rename_all = "camelCase")]
+pub enum AccessorKind {
+  Get,
+  Set,
+}
+
+#[derive(Debug, Clone, Serialize, TS)]
+#[ts(export, export_to = "../../bindings/")]
+#[serde(rename_all = "camelCase")]
+pub struct SpreadProperty {
+  pub span: Span,
+  pub argument: IrExpr,
 }
 
 // ── Opaque (escape hatch) ────────────────────────────────────────────

--- a/crates/js-lowering/src/lower/expressions.rs
+++ b/crates/js-lowering/src/lower/expressions.rs
@@ -1,5 +1,8 @@
 use ehrmantraut_core::ir::{
-  Assignment, BinaryExpr, Call, Identifier, IrExpr, Literal, LiteralValue, MemberAccess, OpaqueExpr,
+  AccessorKind, AccessorProperty, ArrayExpr, Assignment, BinaryExpr, Block, Call, ConditionalExpr,
+  Identifier, IrExpr, KeyValueProperty, Literal, LiteralValue, MemberAccess, MethodProperty,
+  ObjectExpr, ObjectProperty, OpaqueExpr, Param, ShorthandProperty, SpreadProperty, UnaryExpr,
+  UpdateExpr,
 };
 
 use super::{JsLowerer, LowerError};
@@ -254,5 +257,342 @@ impl JsLowerer {
       span: node.span,
       value: LiteralValue::Undefined,
     })
+  }
+
+  // ── Unary / Update ──────────────────────────────────────────────
+
+  pub fn lower_unary_expression(
+    &mut self,
+    node: &crate::cst::CstNode,
+  ) -> Result<IrExpr, LowerError> {
+    let operator = self.child_by_field(node, "operator");
+    let operand = self.child_by_field(node, "argument");
+
+    let op_str = operator.map(|o| self.node_text(o)).unwrap_or_default();
+
+    let operand_expr = match operand {
+      Some(a) => self.lower_expression(a)?,
+      None => IrExpr::Opaque(OpaqueExpr {
+        span: node.span,
+        cst_kind: "missing_operand".to_string(),
+        text: String::new(),
+      }),
+    };
+
+    Ok(IrExpr::UnaryExpr(UnaryExpr {
+      span: node.span,
+      operator: op_str,
+      operand: Box::new(operand_expr),
+      prefix: true,
+    }))
+  }
+
+  pub fn lower_update_expression(
+    &mut self,
+    node: &crate::cst::CstNode,
+  ) -> Result<IrExpr, LowerError> {
+    let operand = self.child_by_field(node, "argument");
+    let operator = self.child_by_field(node, "operator");
+
+    let op_str = operator.map(|o| self.node_text(o)).unwrap_or_default();
+
+    let operand_expr = match operand {
+      Some(a) => self.lower_expression(a)?,
+      None => IrExpr::Opaque(OpaqueExpr {
+        span: node.span,
+        cst_kind: "missing_operand".to_string(),
+        text: String::new(),
+      }),
+    };
+
+    // Determine prefix vs postfix by checking if operator comes before operand
+    let prefix = match (operator, operand) {
+      (Some(op), Some(arg)) => op.span.start.offset < arg.span.start.offset,
+      _ => true,
+    };
+
+    Ok(IrExpr::UpdateExpr(UpdateExpr {
+      span: node.span,
+      operator: op_str,
+      operand: Box::new(operand_expr),
+      prefix,
+    }))
+  }
+
+  // ── Conditional (ternary) ───────────────────────────────────────
+
+  pub fn lower_conditional_expression(
+    &mut self,
+    node: &crate::cst::CstNode,
+  ) -> Result<IrExpr, LowerError> {
+    let condition = self.child_by_field(node, "condition");
+    let consequent = self.child_by_field(node, "consequence");
+    let alternate = self.child_by_field(node, "alternative");
+
+    let cond_expr = match condition {
+      Some(c) => self.lower_expression(c)?,
+      None => IrExpr::Opaque(OpaqueExpr {
+        span: node.span,
+        cst_kind: "missing_condition".to_string(),
+        text: String::new(),
+      }),
+    };
+
+    let cons_expr = match consequent {
+      Some(c) => self.lower_expression(c)?,
+      None => IrExpr::Opaque(OpaqueExpr {
+        span: node.span,
+        cst_kind: "missing_consequent".to_string(),
+        text: String::new(),
+      }),
+    };
+
+    let alt_expr = match alternate {
+      Some(a) => self.lower_expression(a)?,
+      None => IrExpr::Opaque(OpaqueExpr {
+        span: node.span,
+        cst_kind: "missing_alternate".to_string(),
+        text: String::new(),
+      }),
+    };
+
+    Ok(IrExpr::ConditionalExpr(ConditionalExpr {
+      span: node.span,
+      condition: Box::new(cond_expr),
+      consequent: Box::new(cons_expr),
+      alternate: Box::new(alt_expr),
+    }))
+  }
+
+  // ── Array literal ───────────────────────────────────────────────
+
+  pub fn lower_array_expression(
+    &mut self,
+    node: &crate::cst::CstNode,
+  ) -> Result<IrExpr, LowerError> {
+    let mut elements: Vec<Option<IrExpr>> = Vec::new();
+    let mut prev_was_comma = false;
+    let mut first = true;
+
+    for child in &node.children {
+      match child.kind.as_str() {
+        "[" => {
+          first = true;
+          continue;
+        }
+        "]" => {
+          // Trailing comma before ] does NOT create a hole
+          break;
+        }
+        "," => {
+          if first || prev_was_comma {
+            // Hole: either leading comma or consecutive commas
+            elements.push(None);
+          }
+          prev_was_comma = true;
+          first = false;
+          continue;
+        }
+        _ => {
+          if !child.named {
+            continue;
+          }
+          let expr = self.lower_expression(child)?;
+          elements.push(Some(expr));
+          prev_was_comma = false;
+          first = false;
+        }
+      }
+    }
+
+    Ok(IrExpr::ArrayExpr(ArrayExpr {
+      span: node.span,
+      elements,
+    }))
+  }
+
+  // ── Object literal ──────────────────────────────────────────────
+
+  pub fn lower_object_expression(
+    &mut self,
+    node: &crate::cst::CstNode,
+  ) -> Result<IrExpr, LowerError> {
+    let mut properties = Vec::new();
+
+    for child in &node.children {
+      if !child.named {
+        continue;
+      }
+      match child.kind.as_str() {
+        "pair" => {
+          properties.push(self.lower_pair_property(child)?);
+        }
+        "shorthand_property_identifier" | "shorthand_property_identifier_pattern" => {
+          properties.push(ObjectProperty::Shorthand(ShorthandProperty {
+            span: child.span,
+            name: self.node_text(child),
+          }));
+        }
+        "method_definition" => {
+          properties.push(self.lower_method_or_accessor_property(child)?);
+        }
+        "spread_element" => {
+          let argument = self
+            .first_named_child(child)
+            .map(|a| self.lower_expression(a))
+            .transpose()?
+            .unwrap_or(IrExpr::Opaque(OpaqueExpr {
+              span: child.span,
+              cst_kind: "missing_spread_argument".to_string(),
+              text: String::new(),
+            }));
+          properties.push(ObjectProperty::Spread(SpreadProperty {
+            span: child.span,
+            argument,
+          }));
+        }
+        _ => {
+          // Unknown property type — try as key-value fallback
+          properties.push(ObjectProperty::Shorthand(ShorthandProperty {
+            span: child.span,
+            name: self.node_text(child),
+          }));
+        }
+      }
+    }
+
+    Ok(IrExpr::ObjectExpr(ObjectExpr {
+      span: node.span,
+      properties,
+    }))
+  }
+
+  fn lower_pair_property(
+    &mut self,
+    node: &crate::cst::CstNode,
+  ) -> Result<ObjectProperty, LowerError> {
+    let key_node = self.child_by_field(node, "key");
+    let value_node = self.child_by_field(node, "value");
+
+    let computed = key_node
+      .map(|k| k.kind == "computed_property_name")
+      .unwrap_or(false);
+
+    let key = match key_node {
+      Some(k) => {
+        if k.kind == "computed_property_name" {
+          match self.first_named_child(k) {
+            Some(inner) => self.lower_expression(inner)?,
+            None => self.lower_expression(k)?,
+          }
+        } else {
+          self.lower_expression(k)?
+        }
+      }
+      None => IrExpr::Opaque(OpaqueExpr {
+        span: node.span,
+        cst_kind: "missing_key".to_string(),
+        text: String::new(),
+      }),
+    };
+
+    let value = match value_node {
+      Some(v) => self.lower_expression(v)?,
+      None => IrExpr::Opaque(OpaqueExpr {
+        span: node.span,
+        cst_kind: "missing_value".to_string(),
+        text: String::new(),
+      }),
+    };
+
+    Ok(ObjectProperty::KeyValue(KeyValueProperty {
+      span: node.span,
+      key,
+      value,
+      computed,
+    }))
+  }
+
+  fn lower_method_or_accessor_property(
+    &mut self,
+    node: &crate::cst::CstNode,
+  ) -> Result<ObjectProperty, LowerError> {
+    // Check for get/set accessor
+    let has_get = node.children.iter().any(|c| !c.named && c.kind == "get");
+    let has_set = node.children.iter().any(|c| !c.named && c.kind == "set");
+
+    let name_node = self.child_by_field(node, "name");
+    let computed = name_node
+      .map(|n| n.kind == "computed_property_name")
+      .unwrap_or(false);
+
+    let key = match name_node {
+      Some(n) => {
+        if n.kind == "computed_property_name" {
+          match self.first_named_child(n) {
+            Some(inner) => self.lower_expression(inner)?,
+            None => self.lower_expression(n)?,
+          }
+        } else {
+          self.lower_expression(n)?
+        }
+      }
+      None => IrExpr::Opaque(OpaqueExpr {
+        span: node.span,
+        cst_kind: "missing_name".to_string(),
+        text: String::new(),
+      }),
+    };
+
+    let params_node = self.child_by_field(node, "parameters");
+    let params = match params_node {
+      Some(p) => p
+        .children
+        .iter()
+        .filter(|c| c.named && !Self::is_ts_type_node(&c.kind))
+        .map(|c| Param {
+          span: c.span,
+          name: self.node_text(c),
+        })
+        .collect(),
+      None => Vec::new(),
+    };
+
+    let body_node = self.child_by_field(node, "body");
+    let body = match body_node {
+      Some(b) => self.lower_block(b)?,
+      None => Block {
+        span: node.span,
+        body: Vec::new(),
+      },
+    };
+
+    if has_get || has_set {
+      let accessor_kind = if has_get {
+        AccessorKind::Get
+      } else {
+        AccessorKind::Set
+      };
+      return Ok(ObjectProperty::Accessor(AccessorProperty {
+        span: node.span,
+        key,
+        accessor_kind,
+        params,
+        body,
+      }));
+    }
+
+    let is_async = node.children.iter().any(|c| !c.named && c.kind == "async");
+    let is_generator = node.children.iter().any(|c| !c.named && c.kind == "*");
+
+    Ok(ObjectProperty::Method(MethodProperty {
+      span: node.span,
+      key,
+      params,
+      body,
+      computed,
+      is_async,
+      is_generator,
+    }))
   }
 }

--- a/crates/js-lowering/src/lower/mod.rs
+++ b/crates/js-lowering/src/lower/mod.rs
@@ -174,6 +174,11 @@ impl JsLowerer {
       "true" | "false" => Ok(self.lower_boolean_literal(node)),
       "null" => Ok(self.lower_null_literal(node)),
       "undefined" => Ok(self.lower_undefined(node)),
+      "unary_expression" => self.lower_unary_expression(node),
+      "update_expression" => self.lower_update_expression(node),
+      "ternary_expression" => self.lower_conditional_expression(node),
+      "array" => self.lower_array_expression(node),
+      "object" => self.lower_object_expression(node),
       "parenthesized_expression" => {
         // Unwrap parenthesized expression
         match self.first_named_child(node) {


### PR DESCRIPTION
## Summary

- Implement IR lowering for five expression types previously falling through to `OpaqueExpr`
- Add new IR types: `UnaryExpr`, `UpdateExpr`, `ConditionalExpr`, `ArrayExpr`, `ObjectExpr` (with `KeyValue`, `Shorthand`, `Method`, `Accessor`, `Spread` property variants)
- Add 21 new test cases covering all expression types and edge cases (sparse arrays, nested ternaries, computed keys, getters/setters)

## Changes

- `crates/core/src/ir.rs`: Add new expression IR structs and enum variants
- `crates/js-lowering/src/lower/mod.rs`: Register new expression kinds in the dispatcher
- `crates/js-lowering/src/lower/expressions.rs`: Implement lowering logic for all new expression types
- `__test__/lower.spec.ts`: Add comprehensive tests (59 total, 21 new)

Closes #20
Closes #25
Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)