### PR TITLE
feat(lowering): add throw, arrow function, and import/export lowering

### DIFF
--- a/__test__/lower.spec.ts
+++ b/__test__/lower.spec.ts
@@ -247,6 +247,92 @@ test('lower JS class declaration with extends', (t) => {
   t.truthy(node.superClass)
 })
 
+// ── import declarations ────────────────────────────────────────────
+
+test('lower JS default import', (t) => {
+  const node = lower("import x from 'mod';", 'javascript').body[0]
+  if (node.type !== 'importDecl') return t.fail()
+  t.is(node.source, 'mod')
+  t.is(node.specifiers.length, 1)
+  t.is(node.specifiers[0].kind, 'default')
+  if (node.specifiers[0].kind !== 'default') return t.fail()
+  t.is(node.specifiers[0].local, 'x')
+})
+
+test('lower JS named imports', (t) => {
+  const node = lower("import { foo, bar as b } from 'mod';", 'javascript').body[0]
+  if (node.type !== 'importDecl') return t.fail()
+  t.is(node.specifiers.length, 2)
+  if (node.specifiers[0].kind !== 'named') return t.fail()
+  t.is(node.specifiers[0].imported, 'foo')
+  t.is(node.specifiers[0].local, 'foo')
+  if (node.specifiers[1].kind !== 'named') return t.fail()
+  t.is(node.specifiers[1].imported, 'bar')
+  t.is(node.specifiers[1].local, 'b')
+})
+
+test('lower JS namespace import', (t) => {
+  const node = lower("import * as ns from 'mod';", 'javascript').body[0]
+  if (node.type !== 'importDecl') return t.fail()
+  t.is(node.specifiers.length, 1)
+  if (node.specifiers[0].kind !== 'namespace') return t.fail()
+  t.is(node.specifiers[0].local, 'ns')
+})
+
+test('lower JS side-effect import', (t) => {
+  const node = lower("import 'mod';", 'javascript').body[0]
+  if (node.type !== 'importDecl') return t.fail()
+  t.is(node.specifiers.length, 0)
+  t.is(node.source, 'mod')
+})
+
+// ── export declarations ────────────────────────────────────────────
+
+test('lower JS export function declaration', (t) => {
+  const node = lower('export function foo() {}', 'javascript').body[0]
+  if (node.type !== 'functionDecl') return t.fail()
+  t.is(node.annotations.isExport, true)
+  t.is(node.name, 'foo')
+})
+
+test('lower JS export const', (t) => {
+  const node = lower('export const x = 1;', 'javascript').body[0]
+  if (node.type !== 'variableDecl') return t.fail()
+  t.is(node.annotations.isExport, true)
+  t.is(node.name, 'x')
+})
+
+test('lower JS named exports', (t) => {
+  const node = lower('export { x, y as z };', 'javascript').body[0]
+  if (node.type !== 'exportDecl') return t.fail()
+  t.is(node.specifiers.length, 2)
+  t.is(node.specifiers[0].local, 'x')
+  t.is(node.specifiers[0].exported, 'x')
+  t.is(node.specifiers[1].local, 'y')
+  t.is(node.specifiers[1].exported, 'z')
+})
+
+test('lower JS export default expression', (t) => {
+  const node = lower('export default 42;', 'javascript').body[0]
+  if (node.type !== 'exportDecl') return t.fail()
+  t.is(node.isDefault, true)
+  t.truthy(node.declaration)
+})
+
+test('lower JS re-export', (t) => {
+  const node = lower("export { x } from 'mod';", 'javascript').body[0]
+  if (node.type !== 'exportDecl') return t.fail()
+  t.is(node.source, 'mod')
+  t.is(node.specifiers.length, 1)
+})
+
+test('lower JS namespace re-export', (t) => {
+  const node = lower("export * from 'mod';", 'javascript').body[0]
+  if (node.type !== 'exportDecl') return t.fail()
+  t.is(node.source, 'mod')
+  t.is(node.specifiers[0].local, '*')
+})
+
 // ── arrow function expression ──────────────────────────────────────
 
 test('lower JS arrow function concise body', (t) => {

--- a/__test__/lower.spec.ts
+++ b/__test__/lower.spec.ts
@@ -247,6 +247,60 @@ test('lower JS class declaration with extends', (t) => {
   t.truthy(node.superClass)
 })
 
+// ── arrow function expression ──────────────────────────────────────
+
+test('lower JS arrow function concise body', (t) => {
+  const node = lower('const fn = (x) => x + 1;', 'javascript').body[0]
+  if (node.type !== 'variableDecl') return t.fail()
+  if (node.value?.type !== 'functionExpr') return t.fail()
+  t.is(node.value.isArrow, true)
+  t.is(node.value.params.length, 1)
+  t.is(node.value.params[0].name, 'x')
+  // Concise body should be wrapped in implicit return
+  t.is(node.value.body.body.length, 1)
+  t.is(node.value.body.body[0].type, 'return')
+})
+
+test('lower JS arrow function block body', (t) => {
+  const node = lower('const fn = () => { return 1 };', 'javascript').body[0]
+  if (node.type !== 'variableDecl') return t.fail()
+  if (node.value?.type !== 'functionExpr') return t.fail()
+  t.is(node.value.isArrow, true)
+  t.is(node.value.body.body.length, 1)
+  t.is(node.value.body.body[0].type, 'return')
+})
+
+test('lower JS async arrow function', (t) => {
+  const node = lower('const fn = async (x) => x;', 'javascript').body[0]
+  if (node.type !== 'variableDecl') return t.fail()
+  if (node.value?.type !== 'functionExpr') return t.fail()
+  t.is(node.value.isArrow, true)
+  t.is(node.value.annotations.isAsync, true)
+})
+
+test('lower JS arrow function single param no parens', (t) => {
+  const node = lower('const fn = x => x;', 'javascript').body[0]
+  if (node.type !== 'variableDecl') return t.fail()
+  if (node.value?.type !== 'functionExpr') return t.fail()
+  t.is(node.value.params.length, 1)
+  t.is(node.value.params[0].name, 'x')
+})
+
+test('lower JS function expression', (t) => {
+  const node = lower('const fn = function foo(a) { return a };', 'javascript').body[0]
+  if (node.type !== 'variableDecl') return t.fail()
+  if (node.value?.type !== 'functionExpr') return t.fail()
+  t.is(node.value.isArrow, false)
+  t.is(node.value.name, 'foo')
+  t.is(node.value.params.length, 1)
+})
+
+test('lower JS function declaration has isArrow false', (t) => {
+  const node = lower('function foo() {}', 'javascript').body[0]
+  if (node.type !== 'functionDecl') return t.fail()
+  t.is(node.isArrow, false)
+})
+
 // ── throw statement ────────────────────────────────────────────────
 
 test('lower JS throw statement', (t) => {

--- a/__test__/lower.spec.ts
+++ b/__test__/lower.spec.ts
@@ -247,6 +247,21 @@ test('lower JS class declaration with extends', (t) => {
   t.truthy(node.superClass)
 })
 
+// ── throw statement ────────────────────────────────────────────────
+
+test('lower JS throw statement', (t) => {
+  const node = lower('throw new Error("msg");', 'javascript').body[0]
+  if (node.type !== 'throw') return t.fail()
+  t.is(node.argument.type, 'opaque') // new expression is still opaque
+})
+
+test('lower JS throw with expression', (t) => {
+  const node = lower('throw x;', 'javascript').body[0]
+  if (node.type !== 'throw') return t.fail()
+  if (node.argument.type !== 'identifier') return t.fail()
+  t.is(node.argument.name, 'x')
+})
+
 // ── unary expressions ──────────────────────────────────────────────
 
 test('lower JS unary not expression', (t) => {

--- a/crates/core/src/ir.rs
+++ b/crates/core/src/ir.rs
@@ -62,6 +62,7 @@ pub enum IrExpr {
   ConditionalExpr(ConditionalExpr),
   ArrayExpr(ArrayExpr),
   ObjectExpr(ObjectExpr),
+  FunctionExpr(FunctionDecl),
   // Catch-all for expressions we don't lower in detail
   Opaque(OpaqueExpr),
 }
@@ -87,6 +88,7 @@ pub struct FunctionDecl {
   pub params: Vec<Param>,
   pub body: Block,
   pub annotations: Annotations,
+  pub is_arrow: bool,
 }
 
 #[derive(Debug, Clone, Serialize, TS)]

--- a/crates/core/src/ir.rs
+++ b/crates/core/src/ir.rs
@@ -31,6 +31,7 @@ pub enum IrNode {
   Switch(SwitchStmt),
   TryCatch(TryCatchStmt),
   Return(ReturnStmt),
+  Throw(ThrowStmt),
   Break(BreakStmt),
   Continue(ContinueStmt),
 
@@ -201,6 +202,14 @@ pub struct CatchClause {
 pub struct ReturnStmt {
   pub span: Span,
   pub value: Option<IrExpr>,
+}
+
+#[derive(Debug, Clone, Serialize, TS)]
+#[ts(export, export_to = "../../bindings/")]
+#[serde(rename_all = "camelCase")]
+pub struct ThrowStmt {
+  pub span: Span,
+  pub argument: IrExpr,
 }
 
 #[derive(Debug, Clone, Serialize, TS)]

--- a/crates/core/src/ir.rs
+++ b/crates/core/src/ir.rs
@@ -24,6 +24,10 @@ pub enum IrNode {
   FunctionDecl(FunctionDecl),
   ClassDecl(ClassDecl),
 
+  // Module
+  ImportDecl(ImportDecl),
+  ExportDecl(ExportDecl),
+
   // Control flow
   If(IfStmt),
   For(ForStmt),
@@ -108,6 +112,71 @@ pub struct ClassDecl {
   pub super_class: Option<IrExpr>,
   pub body: Vec<IrNode>,
   pub annotations: Annotations,
+}
+
+// ── Module nodes (import / export) ───────────────────────────────────
+
+#[derive(Debug, Clone, Serialize, TS)]
+#[ts(export, export_to = "../../bindings/")]
+#[serde(rename_all = "camelCase")]
+pub struct ImportDecl {
+  pub span: Span,
+  pub specifiers: Vec<ImportSpecifier>,
+  pub source: String,
+}
+
+#[derive(Debug, Clone, Serialize, TS)]
+#[ts(export, export_to = "../../bindings/")]
+#[serde(tag = "kind", rename_all = "camelCase")]
+pub enum ImportSpecifier {
+  Default(ImportDefault),
+  Named(ImportNamed),
+  Namespace(ImportNamespace),
+}
+
+#[derive(Debug, Clone, Serialize, TS)]
+#[ts(export, export_to = "../../bindings/")]
+#[serde(rename_all = "camelCase")]
+pub struct ImportDefault {
+  pub span: Span,
+  pub local: String,
+}
+
+#[derive(Debug, Clone, Serialize, TS)]
+#[ts(export, export_to = "../../bindings/")]
+#[serde(rename_all = "camelCase")]
+pub struct ImportNamed {
+  pub span: Span,
+  pub imported: String,
+  pub local: String,
+}
+
+#[derive(Debug, Clone, Serialize, TS)]
+#[ts(export, export_to = "../../bindings/")]
+#[serde(rename_all = "camelCase")]
+pub struct ImportNamespace {
+  pub span: Span,
+  pub local: String,
+}
+
+#[derive(Debug, Clone, Serialize, TS)]
+#[ts(export, export_to = "../../bindings/")]
+#[serde(rename_all = "camelCase")]
+pub struct ExportDecl {
+  pub span: Span,
+  pub declaration: Option<Box<IrNode>>,
+  pub specifiers: Vec<ExportSpecifier>,
+  pub source: Option<String>,
+  pub is_default: bool,
+}
+
+#[derive(Debug, Clone, Serialize, TS)]
+#[ts(export, export_to = "../../bindings/")]
+#[serde(rename_all = "camelCase")]
+pub struct ExportSpecifier {
+  pub span: Span,
+  pub local: String,
+  pub exported: String,
 }
 
 // ── Control flow nodes ───────────────────────────────────────────────

--- a/crates/js-lowering/src/lower/control_flow.rs
+++ b/crates/js-lowering/src/lower/control_flow.rs
@@ -1,6 +1,6 @@
 use ehrmantraut_core::ir::{
   Block, BreakStmt, CatchClause, ContinueStmt, ForAnnotations, ForKind, ForStmt, IfStmt, IrNode,
-  ReturnStmt, SwitchCase, SwitchStmt, TryCatchStmt, WhileStmt,
+  ReturnStmt, SwitchCase, SwitchStmt, ThrowStmt, TryCatchStmt, WhileStmt,
 };
 
 use super::{JsLowerer, LowerError};
@@ -332,6 +332,28 @@ impl JsLowerer {
     Ok(IrNode::Return(ReturnStmt {
       span: node.span,
       value,
+    }))
+  }
+
+  pub fn lower_throw_statement(
+    &mut self,
+    node: &crate::cst::CstNode,
+  ) -> Result<IrNode, LowerError> {
+    let argument = self
+      .first_named_child(node)
+      .map(|v| self.lower_expression(v))
+      .transpose()?
+      .unwrap_or(ehrmantraut_core::ir::IrExpr::Opaque(
+        ehrmantraut_core::ir::OpaqueExpr {
+          span: node.span,
+          cst_kind: "missing_throw_argument".to_string(),
+          text: String::new(),
+        },
+      ));
+
+    Ok(IrNode::Throw(ThrowStmt {
+      span: node.span,
+      argument,
     }))
   }
 

--- a/crates/js-lowering/src/lower/declarations.rs
+++ b/crates/js-lowering/src/lower/declarations.rs
@@ -1,5 +1,7 @@
 use ehrmantraut_core::ir::{
-  Annotations, Block, ClassDecl, DeclKind, FunctionDecl, IrNode, Param, ScopeLevel, VariableDecl,
+  Annotations, Block, ClassDecl, DeclKind, ExportDecl, ExportSpecifier, FunctionDecl, ImportDecl,
+  ImportDefault, ImportNamed, ImportNamespace, ImportSpecifier, IrNode, Param, ScopeLevel,
+  VariableDecl,
 };
 
 use super::{JsLowerer, LowerError};
@@ -135,6 +137,228 @@ impl JsLowerer {
         declaration_kind: Some(DeclKind::Class),
         ..Default::default()
       },
+    }))
+  }
+
+  // ── Import / Export ──────────────────────────────────────────────
+
+  pub fn lower_import_declaration(
+    &mut self,
+    node: &crate::cst::CstNode,
+  ) -> Result<IrNode, LowerError> {
+    let source = self
+      .child_by_field(node, "source")
+      .map(|s| {
+        let text = self.node_text(s);
+        // Strip quotes
+        if (text.starts_with('"') && text.ends_with('"'))
+          || (text.starts_with('\'') && text.ends_with('\''))
+        {
+          text[1..text.len() - 1].to_string()
+        } else {
+          text
+        }
+      })
+      .unwrap_or_default();
+
+    let mut specifiers = Vec::new();
+
+    for child in &node.children {
+      match child.kind.as_str() {
+        // import x from 'mod'
+        "identifier" => {
+          specifiers.push(ImportSpecifier::Default(ImportDefault {
+            span: child.span,
+            local: self.node_text(child),
+          }));
+        }
+        // import { x, y as z } from 'mod'
+        "import_clause" => {
+          for inner in &child.children {
+            match inner.kind.as_str() {
+              "identifier" => {
+                specifiers.push(ImportSpecifier::Default(ImportDefault {
+                  span: inner.span,
+                  local: self.node_text(inner),
+                }));
+              }
+              "named_imports" => {
+                self.collect_named_imports(inner, &mut specifiers);
+              }
+              "namespace_import" => {
+                let local = self
+                  .first_named_child(inner)
+                  .map(|n| self.node_text(n))
+                  .unwrap_or_default();
+                specifiers.push(ImportSpecifier::Namespace(ImportNamespace {
+                  span: inner.span,
+                  local,
+                }));
+              }
+              _ => {}
+            }
+          }
+        }
+        // import { x } from 'mod' (direct named_imports without import_clause)
+        "named_imports" => {
+          self.collect_named_imports(child, &mut specifiers);
+        }
+        // import * as ns from 'mod'
+        "namespace_import" => {
+          let local = self
+            .first_named_child(child)
+            .map(|n| self.node_text(n))
+            .unwrap_or_default();
+          specifiers.push(ImportSpecifier::Namespace(ImportNamespace {
+            span: child.span,
+            local,
+          }));
+        }
+        _ => {}
+      }
+    }
+
+    Ok(IrNode::ImportDecl(ImportDecl {
+      span: node.span,
+      specifiers,
+      source,
+    }))
+  }
+
+  fn collect_named_imports(
+    &self,
+    node: &crate::cst::CstNode,
+    specifiers: &mut Vec<ImportSpecifier>,
+  ) {
+    for child in &node.children {
+      if child.kind == "import_specifier" {
+        let name_node = self.child_by_field(child, "name");
+        let alias_node = self.child_by_field(child, "alias");
+
+        let imported = name_node.map(|n| self.node_text(n)).unwrap_or_default();
+        let local = alias_node
+          .map(|a| self.node_text(a))
+          .unwrap_or_else(|| imported.clone());
+
+        specifiers.push(ImportSpecifier::Named(ImportNamed {
+          span: child.span,
+          imported,
+          local,
+        }));
+      }
+    }
+  }
+
+  pub fn lower_export_declaration(
+    &mut self,
+    node: &crate::cst::CstNode,
+  ) -> Result<IrNode, LowerError> {
+    let is_default = node
+      .children
+      .iter()
+      .any(|c| !c.named && c.kind == "default");
+
+    let source = self.child_by_field(node, "source").map(|s| {
+      let text = self.node_text(s);
+      if (text.starts_with('"') && text.ends_with('"'))
+        || (text.starts_with('\'') && text.ends_with('\''))
+      {
+        text[1..text.len() - 1].to_string()
+      } else {
+        text
+      }
+    });
+
+    // Check for declaration child (function, class)
+    let decl_child = node.children.iter().find(|c| {
+      matches!(
+        c.kind.as_str(),
+        "function_declaration" | "class_declaration"
+      )
+    });
+
+    if let Some(decl) = decl_child {
+      let mut inner = self.lower_node(decl)?;
+      // Set export annotations on the declaration
+      match &mut inner {
+        Some(IrNode::FunctionDecl(ref mut f)) => {
+          f.annotations.is_export = true;
+          f.annotations.is_default = is_default;
+        }
+        Some(IrNode::ClassDecl(ref mut c)) => {
+          c.annotations.is_export = true;
+          c.annotations.is_default = is_default;
+        }
+        _ => {}
+      }
+      return Ok(
+        inner.unwrap_or(IrNode::Opaque(ehrmantraut_core::ir::OpaqueNode {
+          span: node.span,
+          cst_kind: node.kind.clone(),
+          text: self.node_text(node),
+        })),
+      );
+    }
+
+    // export { x, y as z } or export { x } from 'mod'
+    let mut specifiers = Vec::new();
+    if let Some(export_clause) = node.children.iter().find(|c| c.kind == "export_clause") {
+      for child in &export_clause.children {
+        if child.kind == "export_specifier" {
+          let name_node = self.child_by_field(child, "name");
+          let alias_node = self.child_by_field(child, "alias");
+
+          let local = name_node.map(|n| self.node_text(n)).unwrap_or_default();
+          let exported = alias_node
+            .map(|a| self.node_text(a))
+            .unwrap_or_else(|| local.clone());
+
+          specifiers.push(ExportSpecifier {
+            span: child.span,
+            local,
+            exported,
+          });
+        }
+      }
+    }
+
+    // export default <expression>
+    let declaration = if is_default {
+      node
+        .children
+        .iter()
+        .find(|c| c.named && c.kind != "export_clause" && c.kind != "string")
+        .filter(|c| c.kind != "comment")
+        .map(|c| {
+          let expr = self.lower_expression(c)?;
+          Ok(Box::new(IrNode::ExpressionStatement(
+            ehrmantraut_core::ir::ExpressionStatement {
+              span: c.span,
+              expression: expr,
+            },
+          )))
+        })
+        .transpose()?
+    } else {
+      None
+    };
+
+    // export * from 'mod'
+    let is_namespace_reexport = node.children.iter().any(|c| !c.named && c.kind == "*");
+    if is_namespace_reexport {
+      specifiers.push(ExportSpecifier {
+        span: node.span,
+        local: "*".to_string(),
+        exported: "*".to_string(),
+      });
+    }
+
+    Ok(IrNode::ExportDecl(ExportDecl {
+      span: node.span,
+      declaration,
+      specifiers,
+      source,
+      is_default,
     }))
   }
 

--- a/crates/js-lowering/src/lower/declarations.rs
+++ b/crates/js-lowering/src/lower/declarations.rs
@@ -96,6 +96,7 @@ impl JsLowerer {
         is_generator,
         ..Default::default()
       },
+      is_arrow: false,
     }))
   }
 

--- a/crates/js-lowering/src/lower/expressions.rs
+++ b/crates/js-lowering/src/lower/expressions.rs
@@ -1,8 +1,8 @@
 use ehrmantraut_core::ir::{
-  AccessorKind, AccessorProperty, ArrayExpr, Assignment, BinaryExpr, Block, Call, ConditionalExpr,
-  Identifier, IrExpr, KeyValueProperty, Literal, LiteralValue, MemberAccess, MethodProperty,
-  ObjectExpr, ObjectProperty, OpaqueExpr, Param, ShorthandProperty, SpreadProperty, UnaryExpr,
-  UpdateExpr,
+  AccessorKind, AccessorProperty, Annotations, ArrayExpr, Assignment, BinaryExpr, Block, Call,
+  ConditionalExpr, FunctionDecl, Identifier, IrExpr, IrNode, KeyValueProperty, Literal,
+  LiteralValue, MemberAccess, MethodProperty, ObjectExpr, ObjectProperty, OpaqueExpr, Param,
+  ReturnStmt, ShorthandProperty, SpreadProperty, UnaryExpr, UpdateExpr,
 };
 
 use super::{JsLowerer, LowerError};
@@ -316,6 +316,115 @@ impl JsLowerer {
       operator: op_str,
       operand: Box::new(operand_expr),
       prefix,
+    }))
+  }
+
+  // ── Function expressions ──────────────────────────────────────
+
+  pub fn lower_function_expression(
+    &mut self,
+    node: &crate::cst::CstNode,
+  ) -> Result<IrExpr, LowerError> {
+    let name = self.child_by_field(node, "name").map(|n| self.node_text(n));
+
+    let params_node = self.child_by_field(node, "parameters");
+    let params = match params_node {
+      Some(p) => p
+        .children
+        .iter()
+        .filter(|c| c.named && !Self::is_ts_type_node(&c.kind))
+        .map(|c| Param {
+          span: c.span,
+          name: self.node_text(c),
+        })
+        .collect(),
+      None => Vec::new(),
+    };
+
+    let body_node = self.child_by_field(node, "body");
+    let body = match body_node {
+      Some(b) => self.lower_block(b)?,
+      None => Block {
+        span: node.span,
+        body: Vec::new(),
+      },
+    };
+
+    let is_async = node.children.iter().any(|c| c.kind == "async");
+    let is_generator = node.children.iter().any(|c| c.kind == "*");
+
+    Ok(IrExpr::FunctionExpr(FunctionDecl {
+      span: node.span,
+      name,
+      params,
+      body,
+      annotations: Annotations {
+        is_async,
+        is_generator,
+        ..Default::default()
+      },
+      is_arrow: false,
+    }))
+  }
+
+  // ── Arrow function ────────────────────────────────────────────
+
+  pub fn lower_arrow_function(&mut self, node: &crate::cst::CstNode) -> Result<IrExpr, LowerError> {
+    let is_async = node.children.iter().any(|c| c.kind == "async");
+
+    // Parameters: may be a single identifier or formal_parameters
+    let params = self
+      .child_by_field(node, "parameters")
+      .or_else(|| self.child_by_field(node, "parameter"))
+      .map(|p| {
+        if p.kind == "identifier" {
+          vec![Param {
+            span: p.span,
+            name: self.node_text(p),
+          }]
+        } else {
+          p.children
+            .iter()
+            .filter(|c| c.named && !Self::is_ts_type_node(&c.kind))
+            .map(|c| Param {
+              span: c.span,
+              name: self.node_text(c),
+            })
+            .collect()
+        }
+      })
+      .unwrap_or_default();
+
+    let body_node = self.child_by_field(node, "body");
+    let body = match body_node {
+      Some(b) if b.kind == "statement_block" => self.lower_block(b)?,
+      Some(b) => {
+        // Concise body: wrap expression in implicit return
+        let expr = self.lower_expression(b)?;
+        Block {
+          span: b.span,
+          body: vec![IrNode::Return(ReturnStmt {
+            span: b.span,
+            value: Some(expr),
+          })],
+        }
+      }
+      None => Block {
+        span: node.span,
+        body: Vec::new(),
+      },
+    };
+
+    Ok(IrExpr::FunctionExpr(FunctionDecl {
+      span: node.span,
+      name: None,
+      params,
+      body,
+      annotations: Annotations {
+        is_async,
+        ..Default::default()
+      },
+      is_arrow: true,
     }))
   }
 

--- a/crates/js-lowering/src/lower/mod.rs
+++ b/crates/js-lowering/src/lower/mod.rs
@@ -98,6 +98,7 @@ impl JsLowerer {
       "switch_statement" => Ok(Some(self.lower_switch_statement(node)?)),
       "try_statement" => Ok(Some(self.lower_try_statement(node)?)),
       "return_statement" => Ok(Some(self.lower_return_statement(node)?)),
+      "throw_statement" => Ok(Some(self.lower_throw_statement(node)?)),
       "break_statement" => Ok(Some(self.lower_break_statement(node)?)),
       "continue_statement" => Ok(Some(self.lower_continue_statement(node)?)),
 

--- a/crates/js-lowering/src/lower/mod.rs
+++ b/crates/js-lowering/src/lower/mod.rs
@@ -178,6 +178,9 @@ impl JsLowerer {
       "unary_expression" => self.lower_unary_expression(node),
       "update_expression" => self.lower_update_expression(node),
       "ternary_expression" => self.lower_conditional_expression(node),
+      "arrow_function" => self.lower_arrow_function(node),
+      "function_expression" => self.lower_function_expression(node),
+      "generator_function" => self.lower_function_expression(node),
       "array" => self.lower_array_expression(node),
       "object" => self.lower_object_expression(node),
       "parenthesized_expression" => {

--- a/crates/js-lowering/src/lower/mod.rs
+++ b/crates/js-lowering/src/lower/mod.rs
@@ -63,6 +63,28 @@ impl JsLowerer {
         nodes.extend(self.lower_variable_declaration(child)?);
         continue;
       }
+      // Export statements containing variable declarations need multi-declarator handling
+      if child.kind == "export_statement" {
+        if let Some(decl) = child
+          .children
+          .iter()
+          .find(|c| c.kind == "lexical_declaration" || c.kind == "variable_declaration")
+        {
+          let mut var_nodes = self.lower_variable_declaration(decl)?;
+          for var_node in &mut var_nodes {
+            if let IrNode::VariableDecl(ref mut v) = var_node {
+              v.annotations.is_export = true;
+              v.annotations.declaration_kind = v
+                .annotations
+                .declaration_kind
+                .clone()
+                .or(Some(DeclKind::Import));
+            }
+          }
+          nodes.extend(var_nodes);
+          continue;
+        }
+      }
       if let Some(node) = self.lower_node(child)? {
         nodes.push(node);
       }
@@ -88,6 +110,8 @@ impl JsLowerer {
       }
       "function_declaration" => Ok(Some(self.lower_function_declaration(node)?)),
       "class_declaration" => Ok(Some(self.lower_class_declaration(node)?)),
+      "import_statement" => Ok(Some(self.lower_import_declaration(node)?)),
+      "export_statement" => Ok(Some(self.lower_export_declaration(node)?)),
 
       // Control flow
       "if_statement" => Ok(Some(self.lower_if_statement(node)?)),


### PR DESCRIPTION
## Summary

- Add throw statement lowering with `ThrowStmt` IR node
- Add arrow function and function expression lowering via `FunctionExpr` variant, with `is_arrow` flag on `FunctionDecl` to distinguish arrow from regular functions
- Add import/export declaration lowering with `ImportDecl` (default, named, namespace, side-effect) and `ExportDecl` (named exports, re-exports, default expressions)
- Exported function/class/variable declarations set `annotations.isExport = true` directly

## Changes

- `crates/core/src/ir.rs`: Add `ThrowStmt`, `ImportDecl`, `ExportDecl`, `FunctionExpr` variant, `is_arrow` field
- `crates/js-lowering/src/lower/control_flow.rs`: Implement throw statement lowering
- `crates/js-lowering/src/lower/expressions.rs`: Implement arrow function and function expression lowering
- `crates/js-lowering/src/lower/declarations.rs`: Implement import/export lowering
- `crates/js-lowering/src/lower/mod.rs`: Register new dispatchers, handle export+variable-declaration splitting
- `__test__/lower.spec.ts`: Add 16 new tests (77 total)

Closes #24
Closes #22
Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)