### PR TITLE
feat(lowering): add destructuring pattern and spread expression lowering

### DIFF
--- a/__test__/lower.spec.ts
+++ b/__test__/lower.spec.ts
@@ -596,3 +596,23 @@ test('lower JS empty object', (t) => {
   if (node.expression.type !== 'objectExpr') return t.fail()
   t.is(node.expression.properties.length, 0)
 })
+
+// ── spread expression ─────────────────────────────────────────────
+
+test('lower JS spread in call arguments', (t) => {
+  const node = lower('fn(...args);', 'javascript').body[0]
+  if (node.type !== 'expressionStatement') return t.fail()
+  if (node.expression.type !== 'call') return t.fail()
+  t.is(node.expression.arguments[0].type, 'spreadExpr')
+  if (node.expression.arguments[0].type !== 'spreadExpr') return t.fail()
+  t.is(node.expression.arguments[0].argument.type, 'identifier')
+})
+
+test('lower JS spread in array literal', (t) => {
+  const node = lower('[...arr, 1];', 'javascript').body[0]
+  if (node.type !== 'expressionStatement') return t.fail()
+  if (node.expression.type !== 'arrayExpr') return t.fail()
+  const first = node.expression.elements[0]
+  if (!first) return t.fail()
+  t.is(first.type, 'spreadExpr')
+})

--- a/__test__/lower.spec.ts
+++ b/__test__/lower.spec.ts
@@ -597,6 +597,71 @@ test('lower JS empty object', (t) => {
   t.is(node.expression.properties.length, 0)
 })
 
+// ── destructuring patterns ─────────────────────────────────────────
+
+test('lower JS object destructuring', (t) => {
+  const node = lower('const { x, y } = obj;', 'javascript').body[0]
+  if (node.type !== 'variableDecl') return t.fail()
+  t.is(node.name, '')
+  t.truthy(node.pattern)
+  if (node.pattern?.kind !== 'object') return t.fail()
+  t.is(node.pattern.properties.length, 2)
+  t.is(node.pattern.properties[0].kind, 'shorthand')
+  if (node.pattern.properties[0].kind !== 'shorthand') return t.fail()
+  t.is(node.pattern.properties[0].name, 'x')
+})
+
+test('lower JS array destructuring', (t) => {
+  const node = lower('const [a, b] = arr;', 'javascript').body[0]
+  if (node.type !== 'variableDecl') return t.fail()
+  t.truthy(node.pattern)
+  if (node.pattern?.kind !== 'array') return t.fail()
+  t.is(node.pattern.elements.length, 2)
+})
+
+test('lower JS object destructuring with default', (t) => {
+  const node = lower('const { x = 10 } = obj;', 'javascript').body[0]
+  if (node.type !== 'variableDecl') return t.fail()
+  if (node.pattern?.kind !== 'object') return t.fail()
+  if (node.pattern.properties[0].kind !== 'shorthand') return t.fail()
+  t.truthy(node.pattern.properties[0].defaultValue)
+})
+
+test('lower JS object destructuring with rename', (t) => {
+  const node = lower('const { x: renamed } = obj;', 'javascript').body[0]
+  if (node.type !== 'variableDecl') return t.fail()
+  if (node.pattern?.kind !== 'object') return t.fail()
+  t.is(node.pattern.properties[0].kind, 'keyValue')
+  if (node.pattern.properties[0].kind !== 'keyValue') return t.fail()
+  t.is(node.pattern.properties[0].key, 'x')
+})
+
+test('lower JS object destructuring with rest', (t) => {
+  const node = lower('const { a, ...rest } = obj;', 'javascript').body[0]
+  if (node.type !== 'variableDecl') return t.fail()
+  if (node.pattern?.kind !== 'object') return t.fail()
+  t.is(node.pattern.properties.length, 2)
+  t.is(node.pattern.properties[1].kind, 'rest')
+  if (node.pattern.properties[1].kind !== 'rest') return t.fail()
+  t.is(node.pattern.properties[1].name, 'rest')
+})
+
+test('lower JS function param destructuring', (t) => {
+  const node = lower('function fn({ x, y }) {}', 'javascript').body[0]
+  if (node.type !== 'functionDecl') return t.fail()
+  t.is(node.params[0].name, '')
+  t.truthy(node.params[0].pattern)
+  if (node.params[0].pattern?.kind !== 'object') return t.fail()
+  t.is(node.params[0].pattern.properties.length, 2)
+})
+
+test('lower JS simple variable has no pattern', (t) => {
+  const node = lower('const x = 1;', 'javascript').body[0]
+  if (node.type !== 'variableDecl') return t.fail()
+  t.is(node.name, 'x')
+  t.is(node.pattern, null)
+})
+
 // ── spread expression ─────────────────────────────────────────────
 
 test('lower JS spread in call arguments', (t) => {

--- a/crates/core/src/ir.rs
+++ b/crates/core/src/ir.rs
@@ -67,6 +67,7 @@ pub enum IrExpr {
   ArrayExpr(ArrayExpr),
   ObjectExpr(ObjectExpr),
   FunctionExpr(FunctionDecl),
+  SpreadExpr(SpreadExpr),
   // Catch-all for expressions we don't lower in detail
   Opaque(OpaqueExpr),
 }
@@ -537,6 +538,16 @@ pub enum AccessorKind {
 pub struct SpreadProperty {
   pub span: Span,
   pub argument: IrExpr,
+}
+
+// ── Spread expression ───────────────────────────────────────────────
+
+#[derive(Debug, Clone, Serialize, TS)]
+#[ts(export, export_to = "../../bindings/")]
+#[serde(rename_all = "camelCase")]
+pub struct SpreadExpr {
+  pub span: Span,
+  pub argument: Box<IrExpr>,
 }
 
 // ── Opaque (escape hatch) ────────────────────────────────────────────

--- a/crates/core/src/ir.rs
+++ b/crates/core/src/ir.rs
@@ -81,6 +81,7 @@ pub struct VariableDecl {
   pub span: Span,
   pub name: String,
   pub value: Option<IrExpr>,
+  pub pattern: Option<Pattern>,
   pub annotations: Annotations,
 }
 
@@ -102,6 +103,8 @@ pub struct FunctionDecl {
 pub struct Param {
   pub span: Span,
   pub name: String,
+  pub pattern: Option<Pattern>,
+  pub default_value: Option<IrExpr>,
 }
 
 #[derive(Debug, Clone, Serialize, TS)]
@@ -538,6 +541,86 @@ pub enum AccessorKind {
 pub struct SpreadProperty {
   pub span: Span,
   pub argument: IrExpr,
+}
+
+// ── Destructuring patterns ───────────────────────────────────────────
+
+#[derive(Debug, Clone, Serialize, TS)]
+#[ts(export, export_to = "../../bindings/")]
+#[serde(tag = "kind", rename_all = "camelCase")]
+pub enum Pattern {
+  Object(ObjectPattern),
+  Array(ArrayPattern),
+  Assignment(AssignmentPattern),
+  Rest(RestPattern),
+}
+
+#[derive(Debug, Clone, Serialize, TS)]
+#[ts(export, export_to = "../../bindings/")]
+#[serde(rename_all = "camelCase")]
+pub struct ObjectPattern {
+  pub span: Span,
+  pub properties: Vec<ObjectPatternProperty>,
+}
+
+#[derive(Debug, Clone, Serialize, TS)]
+#[ts(export, export_to = "../../bindings/")]
+#[serde(tag = "kind", rename_all = "camelCase")]
+pub enum ObjectPatternProperty {
+  KeyValue(PatternKeyValue),
+  Shorthand(PatternShorthand),
+  Rest(PatternRest),
+}
+
+#[derive(Debug, Clone, Serialize, TS)]
+#[ts(export, export_to = "../../bindings/")]
+#[serde(rename_all = "camelCase")]
+pub struct PatternKeyValue {
+  pub span: Span,
+  pub key: String,
+  pub value: Pattern,
+}
+
+#[derive(Debug, Clone, Serialize, TS)]
+#[ts(export, export_to = "../../bindings/")]
+#[serde(rename_all = "camelCase")]
+pub struct PatternShorthand {
+  pub span: Span,
+  pub name: String,
+  pub default_value: Option<IrExpr>,
+}
+
+#[derive(Debug, Clone, Serialize, TS)]
+#[ts(export, export_to = "../../bindings/")]
+#[serde(rename_all = "camelCase")]
+pub struct PatternRest {
+  pub span: Span,
+  pub name: String,
+}
+
+#[derive(Debug, Clone, Serialize, TS)]
+#[ts(export, export_to = "../../bindings/")]
+#[serde(rename_all = "camelCase")]
+pub struct ArrayPattern {
+  pub span: Span,
+  pub elements: Vec<Option<Pattern>>,
+}
+
+#[derive(Debug, Clone, Serialize, TS)]
+#[ts(export, export_to = "../../bindings/")]
+#[serde(rename_all = "camelCase")]
+pub struct AssignmentPattern {
+  pub span: Span,
+  pub left: Box<Pattern>,
+  pub right: IrExpr,
+}
+
+#[derive(Debug, Clone, Serialize, TS)]
+#[ts(export, export_to = "../../bindings/")]
+#[serde(rename_all = "camelCase")]
+pub struct RestPattern {
+  pub span: Span,
+  pub argument: Box<Pattern>,
 }
 
 // ── Spread expression ───────────────────────────────────────────────

--- a/crates/js-lowering/src/lower/declarations.rs
+++ b/crates/js-lowering/src/lower/declarations.rs
@@ -1,7 +1,8 @@
 use ehrmantraut_core::ir::{
-  Annotations, Block, ClassDecl, DeclKind, ExportDecl, ExportSpecifier, FunctionDecl, ImportDecl,
-  ImportDefault, ImportNamed, ImportNamespace, ImportSpecifier, IrNode, Param, ScopeLevel,
-  VariableDecl,
+  Annotations, ArrayPattern, AssignmentPattern, Block, ClassDecl, DeclKind, ExportDecl,
+  ExportSpecifier, FunctionDecl, ImportDecl, ImportDefault, ImportNamed, ImportNamespace,
+  ImportSpecifier, IrNode, ObjectPattern, ObjectPatternProperty, Param, Pattern, PatternKeyValue,
+  PatternRest, PatternShorthand, RestPattern, ScopeLevel, VariableDecl,
 };
 
 use super::{JsLowerer, LowerError};
@@ -28,10 +29,16 @@ impl JsLowerer {
 
     let mut nodes = Vec::new();
     for declarator in &declarators {
-      let name = self
-        .child_by_field(declarator, "name")
-        .map(|n| self.node_text(n))
-        .unwrap_or_default();
+      let name_node = self.child_by_field(declarator, "name");
+
+      let (name, pattern) = match name_node {
+        Some(n) if n.kind == "object_pattern" || n.kind == "array_pattern" => {
+          let pat = self.lower_pattern(n)?;
+          (String::new(), Some(pat))
+        }
+        Some(n) => (self.node_text(n), None),
+        None => (String::new(), None),
+      };
 
       let value = self
         .child_by_field(declarator, "value")
@@ -42,6 +49,7 @@ impl JsLowerer {
         span: declarator.span,
         name,
         value,
+        pattern,
         annotations: Annotations {
           scope_level: scope_level.clone(),
           declaration_kind: decl_kind.clone(),
@@ -55,6 +63,7 @@ impl JsLowerer {
         span: node.span,
         name: String::new(),
         value: None,
+        pattern: None,
         annotations: Annotations {
           scope_level,
           declaration_kind: decl_kind,
@@ -369,12 +378,230 @@ impl JsLowerer {
         .children
         .iter()
         .filter(|c| c.named)
-        .map(|c| Param {
-          span: c.span,
-          name: self.node_text(c),
-        })
+        .filter_map(|c| self.lower_param(c).ok())
         .collect(),
       None => Vec::new(),
     }
+  }
+
+  fn lower_param(&mut self, node: &crate::cst::CstNode) -> Result<Param, LowerError> {
+    match node.kind.as_str() {
+      "object_pattern" | "array_pattern" => {
+        let pat = self.lower_pattern(node)?;
+        Ok(Param {
+          span: node.span,
+          name: String::new(),
+          pattern: Some(pat),
+          default_value: None,
+        })
+      }
+      "assignment_pattern" => {
+        let left = self.child_by_field(node, "left");
+        let right = self.child_by_field(node, "right");
+
+        let (name, pattern) = match left {
+          Some(l) if l.kind == "object_pattern" || l.kind == "array_pattern" => {
+            let pat = self.lower_pattern(l)?;
+            (String::new(), Some(pat))
+          }
+          Some(l) => (self.node_text(l), None),
+          None => (String::new(), None),
+        };
+
+        let default_value = right.map(|r| self.lower_expression(r)).transpose()?;
+
+        Ok(Param {
+          span: node.span,
+          name,
+          pattern,
+          default_value,
+        })
+      }
+      "rest_pattern" => {
+        let inner = self.first_named_child(node);
+        let name = inner.map(|n| self.node_text(n)).unwrap_or_default();
+        Ok(Param {
+          span: node.span,
+          name: format!("...{}", name),
+          pattern: None,
+          default_value: None,
+        })
+      }
+      _ => Ok(Param {
+        span: node.span,
+        name: self.node_text(node),
+        pattern: None,
+        default_value: None,
+      }),
+    }
+  }
+
+  // ── Pattern lowering ──────────────────────────────────────────────
+
+  pub(crate) fn lower_pattern(
+    &mut self,
+    node: &crate::cst::CstNode,
+  ) -> Result<Pattern, LowerError> {
+    match node.kind.as_str() {
+      "object_pattern" => self.lower_object_pattern(node),
+      "array_pattern" => self.lower_array_pattern(node),
+      "assignment_pattern" => {
+        let left = self.child_by_field(node, "left");
+        let right = self.child_by_field(node, "right");
+
+        let left_pat = match left {
+          Some(l) => self.lower_pattern(l)?,
+          None => Pattern::Object(ObjectPattern {
+            span: node.span,
+            properties: Vec::new(),
+          }),
+        };
+
+        let right_expr = match right {
+          Some(r) => self.lower_expression(r)?,
+          None => ehrmantraut_core::ir::IrExpr::Opaque(ehrmantraut_core::ir::OpaqueExpr {
+            span: node.span,
+            cst_kind: "missing_default".to_string(),
+            text: String::new(),
+          }),
+        };
+
+        Ok(Pattern::Assignment(AssignmentPattern {
+          span: node.span,
+          left: Box::new(left_pat),
+          right: right_expr,
+        }))
+      }
+      "rest_pattern" => {
+        let inner = self
+          .first_named_child(node)
+          .map(|n| self.lower_pattern(n))
+          .transpose()?
+          .unwrap_or(Pattern::Object(ObjectPattern {
+            span: node.span,
+            properties: Vec::new(),
+          }));
+
+        Ok(Pattern::Rest(RestPattern {
+          span: node.span,
+          argument: Box::new(inner),
+        }))
+      }
+      // Simple identifier treated as a shorthand pattern
+      _ => Ok(Pattern::Object(ObjectPattern {
+        span: node.span,
+        properties: vec![ObjectPatternProperty::Shorthand(PatternShorthand {
+          span: node.span,
+          name: self.node_text(node),
+          default_value: None,
+        })],
+      })),
+    }
+  }
+
+  fn lower_object_pattern(&mut self, node: &crate::cst::CstNode) -> Result<Pattern, LowerError> {
+    let mut properties = Vec::new();
+
+    for child in &node.children {
+      if !child.named {
+        continue;
+      }
+      match child.kind.as_str() {
+        "shorthand_property_identifier_pattern" => {
+          properties.push(ObjectPatternProperty::Shorthand(PatternShorthand {
+            span: child.span,
+            name: self.node_text(child),
+            default_value: None,
+          }));
+        }
+        "pair_pattern" => {
+          let key = self.child_by_field(child, "key");
+          let value = self.child_by_field(child, "value");
+
+          let key_name = key.map(|k| self.node_text(k)).unwrap_or_default();
+          let value_pat = match value {
+            Some(v) => self.lower_pattern(v)?,
+            None => Pattern::Object(ObjectPattern {
+              span: child.span,
+              properties: Vec::new(),
+            }),
+          };
+
+          properties.push(ObjectPatternProperty::KeyValue(PatternKeyValue {
+            span: child.span,
+            key: key_name,
+            value: value_pat,
+          }));
+        }
+        "rest_pattern" => {
+          let inner = self
+            .first_named_child(child)
+            .map(|n| self.node_text(n))
+            .unwrap_or_default();
+          properties.push(ObjectPatternProperty::Rest(PatternRest {
+            span: child.span,
+            name: inner,
+          }));
+        }
+        "assignment_pattern" | "object_assignment_pattern" => {
+          // shorthand with default: { x = 10 }
+          let left = self.child_by_field(child, "left");
+          let right = self.child_by_field(child, "right");
+
+          let name = left.map(|l| self.node_text(l)).unwrap_or_default();
+          let default_value = right.map(|r| self.lower_expression(r)).transpose()?;
+
+          properties.push(ObjectPatternProperty::Shorthand(PatternShorthand {
+            span: child.span,
+            name,
+            default_value,
+          }));
+        }
+        _ => {}
+      }
+    }
+
+    Ok(Pattern::Object(ObjectPattern {
+      span: node.span,
+      properties,
+    }))
+  }
+
+  fn lower_array_pattern(&mut self, node: &crate::cst::CstNode) -> Result<Pattern, LowerError> {
+    let mut elements: Vec<Option<Pattern>> = Vec::new();
+    let mut prev_was_comma = false;
+    let mut first = true;
+
+    for child in &node.children {
+      match child.kind.as_str() {
+        "[" => {
+          first = true;
+          continue;
+        }
+        "]" => break,
+        "," => {
+          if first || prev_was_comma {
+            elements.push(None);
+          }
+          prev_was_comma = true;
+          first = false;
+          continue;
+        }
+        _ => {
+          if !child.named {
+            continue;
+          }
+          let pat = self.lower_pattern(child)?;
+          elements.push(Some(pat));
+          prev_was_comma = false;
+          first = false;
+        }
+      }
+    }
+
+    Ok(Pattern::Array(ArrayPattern {
+      span: node.span,
+      elements,
+    }))
   }
 }

--- a/crates/js-lowering/src/lower/expressions.rs
+++ b/crates/js-lowering/src/lower/expressions.rs
@@ -336,6 +336,8 @@ impl JsLowerer {
         .map(|c| Param {
           span: c.span,
           name: self.node_text(c),
+          pattern: None,
+          default_value: None,
         })
         .collect(),
       None => Vec::new(),
@@ -381,6 +383,8 @@ impl JsLowerer {
           vec![Param {
             span: p.span,
             name: self.node_text(p),
+            pattern: None,
+            default_value: None,
           }]
         } else {
           p.children
@@ -389,6 +393,8 @@ impl JsLowerer {
             .map(|c| Param {
               span: c.span,
               name: self.node_text(c),
+              pattern: None,
+              default_value: None,
             })
             .collect()
         }
@@ -684,6 +690,8 @@ impl JsLowerer {
         .map(|c| Param {
           span: c.span,
           name: self.node_text(c),
+          pattern: None,
+          default_value: None,
         })
         .collect(),
       None => Vec::new(),

--- a/crates/js-lowering/src/lower/expressions.rs
+++ b/crates/js-lowering/src/lower/expressions.rs
@@ -2,7 +2,7 @@ use ehrmantraut_core::ir::{
   AccessorKind, AccessorProperty, Annotations, ArrayExpr, Assignment, BinaryExpr, Block, Call,
   ConditionalExpr, FunctionDecl, Identifier, IrExpr, IrNode, KeyValueProperty, Literal,
   LiteralValue, MemberAccess, MethodProperty, ObjectExpr, ObjectProperty, OpaqueExpr, Param,
-  ReturnStmt, ShorthandProperty, SpreadProperty, UnaryExpr, UpdateExpr,
+  ReturnStmt, ShorthandProperty, SpreadExpr, SpreadProperty, UnaryExpr, UpdateExpr,
 };
 
 use super::{JsLowerer, LowerError};
@@ -425,6 +425,28 @@ impl JsLowerer {
         ..Default::default()
       },
       is_arrow: true,
+    }))
+  }
+
+  // ── Spread ────────────────────────────────────────────────────
+
+  pub fn lower_spread_expression(
+    &mut self,
+    node: &crate::cst::CstNode,
+  ) -> Result<IrExpr, LowerError> {
+    let argument = self
+      .first_named_child(node)
+      .map(|a| self.lower_expression(a))
+      .transpose()?
+      .unwrap_or(IrExpr::Opaque(OpaqueExpr {
+        span: node.span,
+        cst_kind: "missing_spread_argument".to_string(),
+        text: String::new(),
+      }));
+
+    Ok(IrExpr::SpreadExpr(SpreadExpr {
+      span: node.span,
+      argument: Box::new(argument),
     }))
   }
 

--- a/crates/js-lowering/src/lower/mod.rs
+++ b/crates/js-lowering/src/lower/mod.rs
@@ -205,6 +205,7 @@ impl JsLowerer {
       "arrow_function" => self.lower_arrow_function(node),
       "function_expression" => self.lower_function_expression(node),
       "generator_function" => self.lower_function_expression(node),
+      "spread_element" => self.lower_spread_expression(node),
       "array" => self.lower_array_expression(node),
       "object" => self.lower_object_expression(node),
       "parenthesized_expression" => {


### PR DESCRIPTION
## Summary

- Add spread expression lowering as `SpreadExpr` for call arguments, array literals, and general expression contexts
- Add destructuring pattern IR types (`ObjectPattern`, `ArrayPattern`, `AssignmentPattern`, `RestPattern`) for variable declarations and function parameters
- `VariableDecl` gains optional `pattern` field; `Param` gains optional `pattern` and `default_value` fields

## Changes

- `crates/core/src/ir.rs`: Add `SpreadExpr`, `Pattern`, and all pattern subtypes; extend `VariableDecl` and `Param`
- `crates/js-lowering/src/lower/expressions.rs`: Implement `lower_spread_expression`; update `Param` constructors
- `crates/js-lowering/src/lower/declarations.rs`: Implement pattern lowering (`lower_pattern`, `lower_object_pattern`, `lower_array_pattern`); update variable and param handling
- `crates/js-lowering/src/lower/mod.rs`: Register `spread_element` in expression dispatcher
- `__test__/lower.spec.ts`: Add 9 new tests (86 total)

Closes #27
Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)