### PR TITLE
feat(lowering): add new, this/super, and optional chaining expression lowering

### DIFF
--- a/__test__/lower.spec.ts
+++ b/__test__/lower.spec.ts
@@ -681,3 +681,21 @@ test('lower JS spread in array literal', (t) => {
   if (!first) return t.fail()
   t.is(first.type, 'spreadExpr')
 })
+
+// ── this / super ──────────────────────────────────────────────────
+
+test('lower JS this expression', (t) => {
+  const node = lower('this.x;', 'javascript').body[0]
+  if (node.type !== 'expressionStatement') return t.fail()
+  if (node.expression.type !== 'memberAccess') return t.fail()
+  if (node.expression.object.type !== 'identifier') return t.fail()
+  t.is(node.expression.object.name, 'this')
+})
+
+test('lower JS super expression', (t) => {
+  const node = lower('class A extends B { constructor() { super(); } }', 'javascript').body[0]
+  if (node.type !== 'classDecl') return t.fail()
+  // Find the super() call inside constructor body
+  const body = node.body
+  t.truthy(body.length > 0)
+})

--- a/__test__/lower.spec.ts
+++ b/__test__/lower.spec.ts
@@ -392,7 +392,7 @@ test('lower JS function declaration has isArrow false', (t) => {
 test('lower JS throw statement', (t) => {
   const node = lower('throw new Error("msg");', 'javascript').body[0]
   if (node.type !== 'throw') return t.fail()
-  t.is(node.argument.type, 'opaque') // new expression is still opaque
+  t.is(node.argument.type, 'newExpr')
 })
 
 test('lower JS throw with expression', (t) => {
@@ -690,6 +690,24 @@ test('lower JS this expression', (t) => {
   if (node.expression.type !== 'memberAccess') return t.fail()
   if (node.expression.object.type !== 'identifier') return t.fail()
   t.is(node.expression.object.name, 'this')
+})
+
+// ── new expression ────────────────────────────────────────────────
+
+test('lower JS new expression', (t) => {
+  const node = lower('new Foo(1, 2);', 'javascript').body[0]
+  if (node.type !== 'expressionStatement') return t.fail()
+  if (node.expression.type !== 'newExpr') return t.fail()
+  if (node.expression.callee.type !== 'identifier') return t.fail()
+  t.is(node.expression.callee.name, 'Foo')
+  t.is(node.expression.arguments.length, 2)
+})
+
+test('lower JS new expression without args', (t) => {
+  const node = lower('new Foo;', 'javascript').body[0]
+  if (node.type !== 'expressionStatement') return t.fail()
+  if (node.expression.type !== 'newExpr') return t.fail()
+  t.is(node.expression.arguments.length, 0)
 })
 
 test('lower JS super expression', (t) => {

--- a/__test__/lower.spec.ts
+++ b/__test__/lower.spec.ts
@@ -710,6 +710,38 @@ test('lower JS new expression without args', (t) => {
   t.is(node.expression.arguments.length, 0)
 })
 
+// ── optional chaining ─────────────────────────────────────────────
+
+test('lower JS optional member access', (t) => {
+  const node = lower('obj?.prop;', 'javascript').body[0]
+  if (node.type !== 'expressionStatement') return t.fail()
+  if (node.expression.type !== 'memberAccess') return t.fail()
+  t.is(node.expression.optional, true)
+  t.is(node.expression.computed, false)
+})
+
+test('lower JS optional computed access', (t) => {
+  const node = lower('obj?.[0];', 'javascript').body[0]
+  if (node.type !== 'expressionStatement') return t.fail()
+  if (node.expression.type !== 'memberAccess') return t.fail()
+  t.is(node.expression.optional, true)
+  t.is(node.expression.computed, true)
+})
+
+test('lower JS optional call', (t) => {
+  const node = lower('fn?.();', 'javascript').body[0]
+  if (node.type !== 'expressionStatement') return t.fail()
+  if (node.expression.type !== 'call') return t.fail()
+  t.is(node.expression.optional, true)
+})
+
+test('lower JS non-optional member has optional false', (t) => {
+  const node = lower('obj.prop;', 'javascript').body[0]
+  if (node.type !== 'expressionStatement') return t.fail()
+  if (node.expression.type !== 'memberAccess') return t.fail()
+  t.is(node.expression.optional, false)
+})
+
 test('lower JS super expression', (t) => {
   const node = lower('class A extends B { constructor() { super(); } }', 'javascript').body[0]
   if (node.type !== 'classDecl') return t.fail()

--- a/crates/core/src/ir.rs
+++ b/crates/core/src/ir.rs
@@ -67,6 +67,7 @@ pub enum IrExpr {
   ArrayExpr(ArrayExpr),
   ObjectExpr(ObjectExpr),
   FunctionExpr(FunctionDecl),
+  NewExpr(NewExpr),
   SpreadExpr(SpreadExpr),
   // Catch-all for expressions we don't lower in detail
   Opaque(OpaqueExpr),
@@ -621,6 +622,17 @@ pub struct AssignmentPattern {
 pub struct RestPattern {
   pub span: Span,
   pub argument: Box<Pattern>,
+}
+
+// ── New expression ──────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Serialize, TS)]
+#[ts(export, export_to = "../../bindings/")]
+#[serde(rename_all = "camelCase")]
+pub struct NewExpr {
+  pub span: Span,
+  pub callee: Box<IrExpr>,
+  pub arguments: Vec<IrExpr>,
 }
 
 // ── Spread expression ───────────────────────────────────────────────

--- a/crates/core/src/ir.rs
+++ b/crates/core/src/ir.rs
@@ -331,6 +331,7 @@ pub struct Call {
   pub span: Span,
   pub callee: Box<IrExpr>,
   pub arguments: Vec<IrExpr>,
+  pub optional: bool,
 }
 
 #[derive(Debug, Clone, Serialize, TS)]
@@ -341,6 +342,7 @@ pub struct MemberAccess {
   pub object: Box<IrExpr>,
   pub property: Box<IrExpr>,
   pub computed: bool,
+  pub optional: bool,
 }
 
 #[derive(Debug, Clone, Serialize, TS)]

--- a/crates/js-lowering/src/lower/expressions.rs
+++ b/crates/js-lowering/src/lower/expressions.rs
@@ -99,6 +99,7 @@ impl JsLowerer {
       span: node.span,
       callee: Box::new(callee),
       arguments,
+      optional: Self::has_optional_chain(node),
     }))
   }
 
@@ -132,6 +133,7 @@ impl JsLowerer {
       object: Box::new(obj_expr),
       property: Box::new(prop_expr),
       computed: false,
+      optional: Self::has_optional_chain(node),
     }))
   }
 
@@ -165,6 +167,7 @@ impl JsLowerer {
       object: Box::new(obj_expr),
       property: Box::new(idx_expr),
       computed: true,
+      optional: Self::has_optional_chain(node),
     }))
   }
 
@@ -764,5 +767,14 @@ impl JsLowerer {
       is_async,
       is_generator,
     }))
+  }
+
+  // ── Helpers ──────────────────────────────────────────────────────
+
+  fn has_optional_chain(node: &crate::cst::CstNode) -> bool {
+    node
+      .children
+      .iter()
+      .any(|c| c.kind == "optional_chain" || c.field_name.as_deref() == Some("optional_chain"))
   }
 }

--- a/crates/js-lowering/src/lower/expressions.rs
+++ b/crates/js-lowering/src/lower/expressions.rs
@@ -1,8 +1,8 @@
 use ehrmantraut_core::ir::{
   AccessorKind, AccessorProperty, Annotations, ArrayExpr, Assignment, BinaryExpr, Block, Call,
   ConditionalExpr, FunctionDecl, Identifier, IrExpr, IrNode, KeyValueProperty, Literal,
-  LiteralValue, MemberAccess, MethodProperty, ObjectExpr, ObjectProperty, OpaqueExpr, Param,
-  ReturnStmt, ShorthandProperty, SpreadExpr, SpreadProperty, UnaryExpr, UpdateExpr,
+  LiteralValue, MemberAccess, MethodProperty, NewExpr, ObjectExpr, ObjectProperty, OpaqueExpr,
+  Param, ReturnStmt, ShorthandProperty, SpreadExpr, SpreadProperty, UnaryExpr, UpdateExpr,
 };
 
 use super::{JsLowerer, LowerError};
@@ -431,6 +431,37 @@ impl JsLowerer {
         ..Default::default()
       },
       is_arrow: true,
+    }))
+  }
+
+  // ── New expression ────────────────────────────────────────────
+
+  pub fn lower_new_expression(&mut self, node: &crate::cst::CstNode) -> Result<IrExpr, LowerError> {
+    let callee_node = self.child_by_field(node, "constructor");
+    let callee = match callee_node {
+      Some(c) => self.lower_expression(c)?,
+      None => IrExpr::Opaque(OpaqueExpr {
+        span: node.span,
+        cst_kind: "missing_constructor".to_string(),
+        text: String::new(),
+      }),
+    };
+
+    let args_node = self.child_by_field(node, "arguments");
+    let arguments = match args_node {
+      Some(args) => args
+        .children
+        .iter()
+        .filter(|c| c.named)
+        .map(|c| self.lower_expression(c))
+        .collect::<Result<Vec<_>, _>>()?,
+      None => Vec::new(),
+    };
+
+    Ok(IrExpr::NewExpr(NewExpr {
+      span: node.span,
+      callee: Box::new(callee),
+      arguments,
     }))
   }
 

--- a/crates/js-lowering/src/lower/mod.rs
+++ b/crates/js-lowering/src/lower/mod.rs
@@ -182,6 +182,7 @@ impl JsLowerer {
       "binary_expression" => self.lower_binary_expression(node),
       "identifier" | "shorthand_property_identifier" => Ok(self.lower_identifier(node)),
       "property_identifier" => Ok(self.lower_identifier(node)),
+      "this" | "super" => Ok(self.lower_identifier(node)),
       "number" => Ok(self.lower_number_literal(node)),
       "string" => Ok(self.lower_string_literal(node)),
       "template_string" => {

--- a/crates/js-lowering/src/lower/mod.rs
+++ b/crates/js-lowering/src/lower/mod.rs
@@ -206,6 +206,7 @@ impl JsLowerer {
       "arrow_function" => self.lower_arrow_function(node),
       "function_expression" => self.lower_function_expression(node),
       "generator_function" => self.lower_function_expression(node),
+      "new_expression" => self.lower_new_expression(node),
       "spread_element" => self.lower_spread_expression(node),
       "array" => self.lower_array_expression(node),
       "object" => self.lower_object_expression(node),


### PR DESCRIPTION
## Summary

- Add `this`/`super` as Identifier nodes with reserved names
- Add `NewExpr` IR variant for constructor invocations
- Add `optional: bool` field to `MemberAccess` and `Call` for `?.` syntax support

## Changes

- `crates/core/src/ir.rs`: Add `NewExpr` struct; add `optional` field to `MemberAccess` and `Call`
- `crates/js-lowering/src/lower/mod.rs`: Register `this`, `super`, `new_expression` in expression dispatcher
- `crates/js-lowering/src/lower/expressions.rs`: Implement `lower_new_expression`, `has_optional_chain` helper; set `optional` flag on member/call/subscript expressions
- `__test__/lower.spec.ts`: Add 8 new tests (94 total)

Closes #29
Closes #28
Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)