### PR TITLE
feat(lowering): add await/yield and template literal lowering

### DIFF
--- a/__test__/lower.spec.ts
+++ b/__test__/lower.spec.ts
@@ -792,3 +792,38 @@ test('lower JS yield without value', (t) => {
   if (stmt.expression.type !== 'yieldExpr') return t.fail()
   t.is(stmt.expression.argument, null)
 })
+
+// ── template literals ─────────────────────────────────────────────
+
+test('lower JS simple template string (no interpolation)', (t) => {
+  const node = lower('`hello`;', 'javascript').body[0]
+  if (node.type !== 'expressionStatement') return t.fail()
+  t.is(node.expression.type, 'literal')
+})
+
+test('lower JS template literal with interpolation', (t) => {
+  const node = lower('`hello ${name} world`;', 'javascript').body[0]
+  if (node.type !== 'expressionStatement') return t.fail()
+  if (node.expression.type !== 'templateLiteral') return t.fail()
+  t.is(node.expression.quasis.length, 2)
+  t.is(node.expression.quasis[0], 'hello ')
+  t.is(node.expression.quasis[1], ' world')
+  t.is(node.expression.expressions.length, 1)
+  if (node.expression.expressions[0].type !== 'identifier') return t.fail()
+  t.is(node.expression.expressions[0].name, 'name')
+})
+
+test('lower JS template literal with multiple expressions', (t) => {
+  const node = lower('`${a} + ${b}`;', 'javascript').body[0]
+  if (node.type !== 'expressionStatement') return t.fail()
+  if (node.expression.type !== 'templateLiteral') return t.fail()
+  t.is(node.expression.expressions.length, 2)
+  t.is(node.expression.quasis.length, 3)
+})
+
+test('lower JS tagged template as call', (t) => {
+  const node = lower('tag`hello ${x}`;', 'javascript').body[0]
+  if (node.type !== 'expressionStatement') return t.fail()
+  // tree-sitter treats tagged templates as call expressions
+  t.is(node.expression.type, 'call')
+})

--- a/__test__/lower.spec.ts
+++ b/__test__/lower.spec.ts
@@ -749,3 +749,46 @@ test('lower JS super expression', (t) => {
   const body = node.body
   t.truthy(body.length > 0)
 })
+
+// ── await / yield ─────────────────────────────────────────────────
+
+test('lower JS await expression', (t) => {
+  const ir = lower('async function f() { const r = await fetch("/api"); }', 'javascript')
+  const fn = ir.body[0]
+  if (fn.type !== 'functionDecl') return t.fail()
+  const decl = fn.body.body[0]
+  if (decl.type !== 'variableDecl') return t.fail()
+  if (decl.value?.type !== 'awaitExpr') return t.fail()
+  t.is(decl.value.argument.type, 'call')
+})
+
+test('lower JS yield expression', (t) => {
+  const ir = lower('function* gen() { yield 1; }', 'javascript')
+  const fn = ir.body[0]
+  if (fn.type !== 'functionDecl') return t.fail()
+  const stmt = fn.body.body[0]
+  if (stmt.type !== 'expressionStatement') return t.fail()
+  if (stmt.expression.type !== 'yieldExpr') return t.fail()
+  t.is(stmt.expression.delegate, false)
+  t.truthy(stmt.expression.argument)
+})
+
+test('lower JS yield delegate expression', (t) => {
+  const ir = lower('function* gen() { yield* other(); }', 'javascript')
+  const fn = ir.body[0]
+  if (fn.type !== 'functionDecl') return t.fail()
+  const stmt = fn.body.body[0]
+  if (stmt.type !== 'expressionStatement') return t.fail()
+  if (stmt.expression.type !== 'yieldExpr') return t.fail()
+  t.is(stmt.expression.delegate, true)
+})
+
+test('lower JS yield without value', (t) => {
+  const ir = lower('function* gen() { yield; }', 'javascript')
+  const fn = ir.body[0]
+  if (fn.type !== 'functionDecl') return t.fail()
+  const stmt = fn.body.body[0]
+  if (stmt.type !== 'expressionStatement') return t.fail()
+  if (stmt.expression.type !== 'yieldExpr') return t.fail()
+  t.is(stmt.expression.argument, null)
+})

--- a/crates/core/src/ir.rs
+++ b/crates/core/src/ir.rs
@@ -70,6 +70,8 @@ pub enum IrExpr {
   NewExpr(NewExpr),
   AwaitExpr(AwaitExpr),
   YieldExpr(YieldExpr),
+  TemplateLiteral(TemplateLiteral),
+  TaggedTemplate(TaggedTemplate),
   SpreadExpr(SpreadExpr),
   // Catch-all for expressions we don't lower in detail
   Opaque(OpaqueExpr),
@@ -626,6 +628,26 @@ pub struct AssignmentPattern {
 pub struct RestPattern {
   pub span: Span,
   pub argument: Box<Pattern>,
+}
+
+// ── Template literals ────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Serialize, TS)]
+#[ts(export, export_to = "../../bindings/")]
+#[serde(rename_all = "camelCase")]
+pub struct TemplateLiteral {
+  pub span: Span,
+  pub quasis: Vec<String>,
+  pub expressions: Vec<IrExpr>,
+}
+
+#[derive(Debug, Clone, Serialize, TS)]
+#[ts(export, export_to = "../../bindings/")]
+#[serde(rename_all = "camelCase")]
+pub struct TaggedTemplate {
+  pub span: Span,
+  pub tag: Box<IrExpr>,
+  pub quasi: Box<IrExpr>,
 }
 
 // ── Await / Yield ───────────────────────────────────────────────────

--- a/crates/core/src/ir.rs
+++ b/crates/core/src/ir.rs
@@ -68,6 +68,8 @@ pub enum IrExpr {
   ObjectExpr(ObjectExpr),
   FunctionExpr(FunctionDecl),
   NewExpr(NewExpr),
+  AwaitExpr(AwaitExpr),
+  YieldExpr(YieldExpr),
   SpreadExpr(SpreadExpr),
   // Catch-all for expressions we don't lower in detail
   Opaque(OpaqueExpr),
@@ -624,6 +626,25 @@ pub struct AssignmentPattern {
 pub struct RestPattern {
   pub span: Span,
   pub argument: Box<Pattern>,
+}
+
+// ── Await / Yield ───────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Serialize, TS)]
+#[ts(export, export_to = "../../bindings/")]
+#[serde(rename_all = "camelCase")]
+pub struct AwaitExpr {
+  pub span: Span,
+  pub argument: Box<IrExpr>,
+}
+
+#[derive(Debug, Clone, Serialize, TS)]
+#[ts(export, export_to = "../../bindings/")]
+#[serde(rename_all = "camelCase")]
+pub struct YieldExpr {
+  pub span: Span,
+  pub argument: Option<Box<IrExpr>>,
+  pub delegate: bool,
 }
 
 // ── New expression ──────────────────────────────────────────────────

--- a/crates/js-lowering/src/lower/expressions.rs
+++ b/crates/js-lowering/src/lower/expressions.rs
@@ -1,8 +1,9 @@
 use ehrmantraut_core::ir::{
-  AccessorKind, AccessorProperty, Annotations, ArrayExpr, Assignment, BinaryExpr, Block, Call,
-  ConditionalExpr, FunctionDecl, Identifier, IrExpr, IrNode, KeyValueProperty, Literal,
+  AccessorKind, AccessorProperty, Annotations, ArrayExpr, Assignment, AwaitExpr, BinaryExpr, Block,
+  Call, ConditionalExpr, FunctionDecl, Identifier, IrExpr, IrNode, KeyValueProperty, Literal,
   LiteralValue, MemberAccess, MethodProperty, NewExpr, ObjectExpr, ObjectProperty, OpaqueExpr,
   Param, ReturnStmt, ShorthandProperty, SpreadExpr, SpreadProperty, UnaryExpr, UpdateExpr,
+  YieldExpr,
 };
 
 use super::{JsLowerer, LowerError};
@@ -434,6 +435,47 @@ impl JsLowerer {
         ..Default::default()
       },
       is_arrow: true,
+    }))
+  }
+
+  // ── Await / Yield ─────────────────────────────────────────────
+
+  pub fn lower_await_expression(
+    &mut self,
+    node: &crate::cst::CstNode,
+  ) -> Result<IrExpr, LowerError> {
+    let argument = self
+      .first_named_child(node)
+      .map(|a| self.lower_expression(a))
+      .transpose()?
+      .unwrap_or(IrExpr::Opaque(OpaqueExpr {
+        span: node.span,
+        cst_kind: "missing_await_argument".to_string(),
+        text: String::new(),
+      }));
+
+    Ok(IrExpr::AwaitExpr(AwaitExpr {
+      span: node.span,
+      argument: Box::new(argument),
+    }))
+  }
+
+  pub fn lower_yield_expression(
+    &mut self,
+    node: &crate::cst::CstNode,
+  ) -> Result<IrExpr, LowerError> {
+    let delegate = node.children.iter().any(|c| !c.named && c.kind == "*");
+
+    let argument = self
+      .first_named_child(node)
+      .map(|a| self.lower_expression(a))
+      .transpose()?
+      .map(Box::new);
+
+    Ok(IrExpr::YieldExpr(YieldExpr {
+      span: node.span,
+      argument,
+      delegate,
     }))
   }
 

--- a/crates/js-lowering/src/lower/expressions.rs
+++ b/crates/js-lowering/src/lower/expressions.rs
@@ -2,8 +2,8 @@ use ehrmantraut_core::ir::{
   AccessorKind, AccessorProperty, Annotations, ArrayExpr, Assignment, AwaitExpr, BinaryExpr, Block,
   Call, ConditionalExpr, FunctionDecl, Identifier, IrExpr, IrNode, KeyValueProperty, Literal,
   LiteralValue, MemberAccess, MethodProperty, NewExpr, ObjectExpr, ObjectProperty, OpaqueExpr,
-  Param, ReturnStmt, ShorthandProperty, SpreadExpr, SpreadProperty, UnaryExpr, UpdateExpr,
-  YieldExpr,
+  Param, ReturnStmt, ShorthandProperty, SpreadExpr, SpreadProperty, TemplateLiteral, UnaryExpr,
+  UpdateExpr, YieldExpr,
 };
 
 use super::{JsLowerer, LowerError};
@@ -435,6 +435,51 @@ impl JsLowerer {
         ..Default::default()
       },
       is_arrow: true,
+    }))
+  }
+
+  // ── Template literal ──────────────────────────────────────────
+
+  pub fn lower_template_string(
+    &mut self,
+    node: &crate::cst::CstNode,
+  ) -> Result<IrExpr, LowerError> {
+    let has_interpolation = node
+      .children
+      .iter()
+      .any(|c| c.kind == "template_substitution");
+
+    if !has_interpolation {
+      // Simple template string without interpolation — lower as string literal
+      return Ok(self.lower_string_literal(node));
+    }
+
+    let mut quasis = Vec::new();
+    let mut expressions = Vec::new();
+    let mut current_quasi = String::new();
+
+    for child in &node.children {
+      match child.kind.as_str() {
+        "string_fragment" | "escape_sequence" => {
+          current_quasi.push_str(&self.node_text(child));
+        }
+        "template_substitution" => {
+          quasis.push(std::mem::take(&mut current_quasi));
+          if let Some(expr_node) = self.first_named_child(child) {
+            let expr = self.lower_expression(expr_node)?;
+            expressions.push(expr);
+          }
+        }
+        _ => {}
+      }
+    }
+    // Push the trailing quasi
+    quasis.push(current_quasi);
+
+    Ok(IrExpr::TemplateLiteral(TemplateLiteral {
+      span: node.span,
+      quasis,
+      expressions,
     }))
   }
 

--- a/crates/js-lowering/src/lower/mod.rs
+++ b/crates/js-lowering/src/lower/mod.rs
@@ -187,18 +187,7 @@ impl JsLowerer {
       "this" | "super" => Ok(self.lower_identifier(node)),
       "number" => Ok(self.lower_number_literal(node)),
       "string" => Ok(self.lower_string_literal(node)),
-      "template_string" => {
-        let text = self.node_text(node);
-        if text.contains("${") {
-          Ok(IrExpr::Opaque(OpaqueExpr {
-            span: node.span,
-            cst_kind: node.kind.clone(),
-            text,
-          }))
-        } else {
-          Ok(self.lower_string_literal(node))
-        }
-      }
+      "template_string" => self.lower_template_string(node),
       "true" | "false" => Ok(self.lower_boolean_literal(node)),
       "null" => Ok(self.lower_null_literal(node)),
       "undefined" => Ok(self.lower_undefined(node)),

--- a/crates/js-lowering/src/lower/mod.rs
+++ b/crates/js-lowering/src/lower/mod.rs
@@ -108,7 +108,9 @@ impl JsLowerer {
       "lexical_declaration" | "variable_declaration" => {
         Ok(self.lower_variable_declaration(node)?.into_iter().next())
       }
-      "function_declaration" => Ok(Some(self.lower_function_declaration(node)?)),
+      "function_declaration" | "generator_function_declaration" => {
+        Ok(Some(self.lower_function_declaration(node)?))
+      }
       "class_declaration" => Ok(Some(self.lower_class_declaration(node)?)),
       "import_statement" => Ok(Some(self.lower_import_declaration(node)?)),
       "export_statement" => Ok(Some(self.lower_export_declaration(node)?)),
@@ -207,6 +209,8 @@ impl JsLowerer {
       "function_expression" => self.lower_function_expression(node),
       "generator_function" => self.lower_function_expression(node),
       "new_expression" => self.lower_new_expression(node),
+      "await_expression" => self.lower_await_expression(node),
+      "yield_expression" => self.lower_yield_expression(node),
       "spread_element" => self.lower_spread_expression(node),
       "array" => self.lower_array_expression(node),
       "object" => self.lower_object_expression(node),


### PR DESCRIPTION
## Summary

- Add `AwaitExpr` and `YieldExpr` IR variants for async/generator expressions
- Register `generator_function_declaration` in statement dispatcher
- Add `TemplateLiteral` IR variant with quasis/expressions split for interpolated template strings
- Simple template strings without `${}` remain as `Literal`; tagged templates handled as `Call`

## Changes

- `crates/core/src/ir.rs`: Add `AwaitExpr`, `YieldExpr`, `TemplateLiteral`, `TaggedTemplate` types
- `crates/js-lowering/src/lower/expressions.rs`: Implement await/yield/template literal lowering
- `crates/js-lowering/src/lower/mod.rs`: Register new expression kinds and generator function declaration
- `__test__/lower.spec.ts`: Add 8 new tests (102 total)

Closes #31
Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)