### PR TITLE
fix(lowering): remove incorrect DeclKind::Import fallback for exported variables

### DIFF
--- a/crates/js-lowering/src/lower/mod.rs
+++ b/crates/js-lowering/src/lower/mod.rs
@@ -74,11 +74,6 @@ impl JsLowerer {
           for var_node in &mut var_nodes {
             if let IrNode::VariableDecl(ref mut v) = var_node {
               v.annotations.is_export = true;
-              v.annotations.declaration_kind = v
-                .annotations
-                .declaration_kind
-                .clone()
-                .or(Some(DeclKind::Import));
             }
           }
           nodes.extend(var_nodes);


### PR DESCRIPTION
## Summary

Exported variable declarations (`export const x = 1`, `export let y = 2`) were incorrectly annotated with `DeclKind::Import` when `declaration_kind` was `None`. The `.or(Some(DeclKind::Import))` fallback has been removed since `lower_variable_declaration` already correctly sets the declaration kind from the keyword (`let`, `const`, `var`).

## Changes

- Removed the erroneous `.or(Some(DeclKind::Import))` fallback in the export statement handling path (`crates/js-lowering/src/lower/mod.rs`)

Closes #43