### PR TITLE
fix(lowering): add defensive bounds checks for string and byte slicing

### DIFF
--- a/crates/js-lowering/src/lower/declarations.rs
+++ b/crates/js-lowering/src/lower/declarations.rs
@@ -158,17 +158,7 @@ impl JsLowerer {
   ) -> Result<IrNode, LowerError> {
     let source = self
       .child_by_field(node, "source")
-      .map(|s| {
-        let text = self.node_text(s);
-        // Strip quotes
-        if (text.starts_with('"') && text.ends_with('"'))
-          || (text.starts_with('\'') && text.ends_with('\''))
-        {
-          text[1..text.len() - 1].to_string()
-        } else {
-          text
-        }
-      })
+      .map(|s| Self::strip_quotes(self.node_text(s)))
       .unwrap_or_default();
 
     let mut specifiers = Vec::new();
@@ -268,16 +258,9 @@ impl JsLowerer {
       .iter()
       .any(|c| !c.named && c.kind == "default");
 
-    let source = self.child_by_field(node, "source").map(|s| {
-      let text = self.node_text(s);
-      if (text.starts_with('"') && text.ends_with('"'))
-        || (text.starts_with('\'') && text.ends_with('\''))
-      {
-        text[1..text.len() - 1].to_string()
-      } else {
-        text
-      }
-    });
+    let source = self
+      .child_by_field(node, "source")
+      .map(|s| Self::strip_quotes(self.node_text(s)));
 
     // Check for declaration child (function, class)
     let decl_child = node.children.iter().find(|c| {

--- a/crates/js-lowering/src/lower/expressions.rs
+++ b/crates/js-lowering/src/lower/expressions.rs
@@ -226,15 +226,7 @@ impl JsLowerer {
 
   pub fn lower_string_literal(&self, node: &crate::cst::CstNode) -> IrExpr {
     let text = self.node_text(node);
-    // Strip surrounding quotes
-    let inner = if (text.starts_with('"') && text.ends_with('"'))
-      || (text.starts_with('\'') && text.ends_with('\''))
-      || (text.starts_with('`') && text.ends_with('`'))
-    {
-      text[1..text.len() - 1].to_string()
-    } else {
-      text
-    };
+    let inner = Self::strip_quotes(text);
     IrExpr::Literal(Literal {
       span: node.span,
       value: LiteralValue::String(inner),

--- a/crates/js-lowering/src/lower/mod.rs
+++ b/crates/js-lowering/src/lower/mod.rs
@@ -276,6 +276,18 @@ impl JsLowerer {
       .join("")
   }
 
+  pub(crate) fn strip_quotes(text: String) -> String {
+    if text.len() >= 2
+      && ((text.starts_with('"') && text.ends_with('"'))
+        || (text.starts_with('\'') && text.ends_with('\''))
+        || (text.starts_with('`') && text.ends_with('`')))
+    {
+      text[1..text.len() - 1].to_string()
+    } else {
+      text
+    }
+  }
+
   pub(crate) fn decl_kind_and_scope(kind_str: &str) -> (Option<DeclKind>, Option<ScopeLevel>) {
     match kind_str {
       "let" => (Some(DeclKind::Let), Some(ScopeLevel::Block)),

--- a/crates/js-lowering/src/lower/mod.rs
+++ b/crates/js-lowering/src/lower/mod.rs
@@ -256,7 +256,7 @@ impl JsLowerer {
     if !self.source.is_empty() {
       let start = node.span.start.offset as usize;
       let end = node.span.end.offset as usize;
-      if end <= self.source.len() {
+      if start <= end && end <= self.source.len() {
         return self.source[start..end].to_string();
       }
     }

--- a/crates/js-lowering/src/parser.rs
+++ b/crates/js-lowering/src/parser.rs
@@ -52,14 +52,14 @@ fn tree_to_cst(node: tree_sitter::Node, source: &str, field_name: Option<&str>) 
 
   let span = Span {
     start: Position {
-      line: start.row as u32,
-      column: start.column as u32,
-      offset: node.start_byte() as u32,
+      line: u32::try_from(start.row).unwrap_or(u32::MAX),
+      column: u32::try_from(start.column).unwrap_or(u32::MAX),
+      offset: u32::try_from(node.start_byte()).unwrap_or(u32::MAX),
     },
     end: Position {
-      line: end.row as u32,
-      column: end.column as u32,
-      offset: node.end_byte() as u32,
+      line: u32::try_from(end.row).unwrap_or(u32::MAX),
+      column: u32::try_from(end.column).unwrap_or(u32::MAX),
+      offset: u32::try_from(node.end_byte()).unwrap_or(u32::MAX),
     },
   };
 
@@ -76,7 +76,9 @@ fn tree_to_cst(node: tree_sitter::Node, source: &str, field_name: Option<&str>) 
     .collect();
 
   let text = if child_count == 0 {
-    Some(source[node.start_byte()..node.end_byte()].to_string())
+    source
+      .get(node.start_byte()..node.end_byte())
+      .map(|s| s.to_string())
   } else {
     None
   };


### PR DESCRIPTION
## Summary

Added defensive bounds checks across multiple slicing operations in the lowering and parser code to prevent panics on malformed or edge-case input.

## Changes

- Extracted a shared `strip_quotes` helper with `len >= 2` guard, replacing 3 duplicated inline patterns (`expressions.rs`, `declarations.rs` x2)
- Added `start <= end` validation in `node_text` before slicing source string
- Used `source.get(start..end)` instead of direct indexing in CST parser for safe byte slicing
- Replaced bare `as u32` casts with `u32::try_from().unwrap_or(u32::MAX)` for tree-sitter byte offsets

Closes #44