### PR TITLE
fix(lowering): replace silent fallbacks with opaque variants for unknown node types

### DIFF
--- a/crates/core/src/ir.rs
+++ b/crates/core/src/ir.rs
@@ -557,6 +557,7 @@ pub enum ObjectProperty {
   Method(MethodProperty),
   Accessor(AccessorProperty),
   Spread(SpreadProperty),
+  Opaque(OpaqueExpr),
 }
 
 #[derive(Debug, Clone, Serialize, TS)]
@@ -627,6 +628,7 @@ pub enum Pattern {
   Array(ArrayPattern),
   Assignment(AssignmentPattern),
   Rest(RestPattern),
+  Opaque(OpaqueExpr),
 }
 
 #[derive(Debug, Clone, Serialize, TS)]

--- a/crates/js-lowering/src/lower/declarations.rs
+++ b/crates/js-lowering/src/lower/declarations.rs
@@ -610,13 +610,18 @@ impl JsLowerer {
         }))
       }
       // Simple identifier treated as a shorthand pattern
-      _ => Ok(Pattern::Object(ObjectPattern {
+      "identifier" => Ok(Pattern::Object(ObjectPattern {
         span: node.span,
         properties: vec![ObjectPatternProperty::Shorthand(PatternShorthand {
           span: node.span,
           name: self.node_text(node),
           default_value: None,
         })],
+      })),
+      _ => Ok(Pattern::Opaque(ehrmantraut_core::ir::OpaqueExpr {
+        span: node.span,
+        cst_kind: node.kind.clone(),
+        text: self.node_text(node),
       })),
     }
   }

--- a/crates/js-lowering/src/lower/expressions.rs
+++ b/crates/js-lowering/src/lower/expressions.rs
@@ -731,10 +731,10 @@ impl JsLowerer {
           }));
         }
         _ => {
-          // Unknown property type — try as key-value fallback
-          properties.push(ObjectProperty::Shorthand(ShorthandProperty {
+          properties.push(ObjectProperty::Opaque(OpaqueExpr {
             span: child.span,
-            name: self.node_text(child),
+            cst_kind: child.kind.clone(),
+            text: self.node_text(child),
           }));
         }
       }


### PR DESCRIPTION
## Summary

Unknown/unrecognized node types in pattern lowering and object literal lowering were silently converted into semantically incorrect IR types (`ObjectPattern` with shorthand, `ShorthandProperty`). Replaced these with `Opaque` variants consistent with the `OpaqueExpr`/`OpaqueNode` pattern used elsewhere in the codebase.

## Changes

- Added `Opaque(OpaqueExpr)` variant to `Pattern` enum (`ir.rs`)
- Added `Opaque(OpaqueExpr)` variant to `ObjectProperty` enum (`ir.rs`)
- In `lower_pattern`: separated `"identifier"` as explicit match arm for shorthand; `_` now returns `Pattern::Opaque`
- In `lower_object_expression`: `_` now returns `ObjectProperty::Opaque` instead of `ShorthandProperty`

Closes #46