### PR TITLE
fix(lowering): harden for..of detection against grammar changes

### DIFF
--- a/crates/js-lowering/src/lower/control_flow.rs
+++ b/crates/js-lowering/src/lower/control_flow.rs
@@ -102,8 +102,10 @@ impl JsLowerer {
     &mut self,
     node: &crate::cst::CstNode,
   ) -> Result<IrNode, LowerError> {
-    // Determine if this is for..in or for..of
-    let is_of = node.kind == "for_in_statement" && node.children.iter().any(|c| c.kind == "of");
+    // Determine if this is for..in or for..of.
+    // Current tree-sitter-javascript uses "for_in_statement" for both, with an "of" child for for..of.
+    // Also handle a potential future "for_of_statement" node kind for grammar evolution.
+    let is_of = node.kind == "for_of_statement" || node.children.iter().any(|c| c.kind == "of");
     let kind = if is_of { ForKind::Of } else { ForKind::In };
 
     let left = self

--- a/crates/js-lowering/src/lower/mod.rs
+++ b/crates/js-lowering/src/lower/mod.rs
@@ -113,7 +113,7 @@ impl JsLowerer {
       // Control flow
       "if_statement" => Ok(Some(self.lower_if_statement(node)?)),
       "for_statement" => Ok(Some(self.lower_for_statement(node)?)),
-      "for_in_statement" => Ok(Some(self.lower_for_in_statement(node)?)),
+      "for_in_statement" | "for_of_statement" => Ok(Some(self.lower_for_in_statement(node)?)),
       "while_statement" => Ok(Some(self.lower_while_statement(node)?)),
       "do_statement" => Ok(Some(self.lower_do_while_statement(node)?)),
       "switch_statement" => Ok(Some(self.lower_switch_statement(node)?)),


### PR DESCRIPTION
## Summary

Made `for..of` loop detection robust against potential tree-sitter grammar evolution by adding `"for_of_statement"` as an additional match arm in the statement dispatcher and updating the detection logic to handle it directly.

## Changes

- Added `"for_of_statement"` match arm in `lower_node` dispatch (`mod.rs`), routing to the same `lower_for_in_statement` handler
- Updated `lower_for_in_statement` to detect `for..of` via `node.kind == "for_of_statement"` in addition to the existing `"of"` child heuristic

Closes #48