### PR TITLE
docs(lowering): document prefix default for malformed update expressions

### DIFF
--- a/crates/js-lowering/src/lower/expressions.rs
+++ b/crates/js-lowering/src/lower/expressions.rs
@@ -315,7 +315,9 @@ impl JsLowerer {
       }),
     };
 
-    // Determine prefix vs postfix by checking if operator comes before operand
+    // Determine prefix vs postfix by comparing span offsets of operator and operand.
+    // If either is missing (malformed CST), default to prefix as a reasonable fallback
+    // since the exact form cannot be determined and the operand is already lowered as OpaqueExpr.
     let prefix = match (operator, operand) {
       (Some(op), Some(arg)) => op.span.start.offset < arg.span.start.offset,
       _ => true,


### PR DESCRIPTION
## Summary

Documented the intentional design decision of defaulting to `prefix = true` when the update expression CST is malformed (missing operator or operand nodes). This is the safer default since prefix is the more common form and the operand is already represented as `OpaqueExpr` in that case.

## Changes

- Added explanatory comment on the `true` default in `lower_update_expression` (`expressions.rs`)

Closes #49